### PR TITLE
Kontroller at det ikke "nedgraderes" til en tidligere status.

### DIFF
--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
@@ -116,8 +116,14 @@ class DelbestillingService(
         return DelbestillingResultat(id, null, saksnummer = lagretSaksnummer)
     }
 
-    fun oppdaterStatus(id: Long, status: Status) {
-        delbestillingRepository.oppdaterStatus(id, status)
+
+    suspend fun oppdaterStatus(id: Long, status: Status) {
+        delbestillingRepository.withTransaction { tx ->
+            val nåværendeStatus = delbestillingRepository.hentDelbestilling(tx, id)!!.status
+            if (nåværendeStatus.ordinal < status.ordinal) {
+                delbestillingRepository.oppdaterStatus(tx, id, status)
+            }
+        }
     }
 
     private fun validerDelbestillingRate(bestillerFnr: String, hmsnr: String, serienr: String): DelbestillingFeil? {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/Status.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/Status.kt
@@ -5,5 +5,7 @@ enum class Status {
     INNSENDT,
 
     // Fra Oebs
-    REGISTRERT, KLARGJORT, LUKKET
+    REGISTRERT,
+    KLARGJORT,
+    LUKKET
 }

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingServiceTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingServiceTest.kt
@@ -114,4 +114,17 @@ internal class DelbestillingServiceTest {
         delbestillingService.oppdaterStatus(delbestilling.saksnummer, Status.KLARGJORT)
         assertEquals(Status.KLARGJORT, delbestillingService.hentDelbestillinger(bestillerFnr).first().status)
     }
+
+    @Test
+    fun `skal ikke kunne oppdatere delbestilling til en tidligere status`() = runTest {
+        coEvery { oebsService.sendDelbestilling(any()) } just runs
+        delbestillingService.opprettDelbestilling(delbestillingRequest(), bestillerFnr, bestillerTokenString)
+        val delbestilling = delbestillingService.hentDelbestillinger(bestillerFnr).first()
+        delbestillingService.oppdaterStatus(delbestilling.saksnummer, Status.KLARGJORT)
+
+        // Denne skal ikke ha noen effekt
+        delbestillingService.oppdaterStatus(delbestilling.saksnummer, Status.REGISTRERT)
+
+        assertEquals(Status.KLARGJORT, delbestillingService.hentDelbestillinger(bestillerFnr).first().status)
+    }
 }


### PR DESCRIPTION
REGISTRERT og KLARGJORT kommer ofte omtrent samtidig, som kan føre til at oppdaterStatus(KLARGJORT) blir kalt før oppdaterStatus(REGISTRERT).