### PR TITLE
Sett navn på hovedprodukter i delbestillinger

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,7 +8,7 @@ on:
       - "CODEOWNERS"
     branches:
       - main
-      - skipningsbekreftelse2
+      - import-navn
 
 jobs:
   build-and-deploy:

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/Application.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/Application.kt
@@ -8,6 +8,8 @@ import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import no.nav.hjelpemidler.delbestilling.delbestilling.azureRoutes
 import no.nav.hjelpemidler.delbestilling.delbestilling.delbestillingApiAuthenticated
@@ -29,7 +31,11 @@ fun Application.module() {
 
     environment.monitor.subscribe(ApplicationStarted) {
         logg.info { "environment.monitor.subscribe(ApplicationStarted)" }
-        RunOnStart().importNavn()
+        runBlocking {
+            launch {
+                RunOnStart().importNavn()
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/Application.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/Application.kt
@@ -2,26 +2,35 @@ package no.nav.hjelpemidler.delbestilling
 
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.ApplicationStarted
 import io.ktor.server.auth.authenticate
 import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
+import mu.KotlinLogging
 import no.nav.hjelpemidler.delbestilling.delbestilling.azureRoutes
 import no.nav.hjelpemidler.delbestilling.delbestilling.delbestillingApiAuthenticated
 import no.nav.hjelpemidler.delbestilling.delbestilling.delbestillingApiPublic
 import no.nav.hjelpemidler.delbestilling.plugins.medDelbestillerRolle
+import no.nav.hjelpemidler.delbestilling.roller.RunOnStart
 import no.nav.hjelpemidler.hjelpemidler.hjelpemidler.hjelpemiddelApi
 import no.nav.tms.token.support.azure.validation.AzureAuthenticator
 import no.nav.tms.token.support.tokenx.validation.TokenXAuthenticator
-import no.nav.tms.token.support.tokenx.validation.user.TokenXUser
 import no.nav.tms.token.support.tokenx.validation.user.TokenXUserFactory
 
 fun main(args: Array<String>): Unit = io.ktor.server.cio.EngineMain.main(args)
 
+private val logg = KotlinLogging.logger {}
+
 fun Application.module() {
     configure()
     setupRoutes()
+
+    environment.monitor.subscribe(ApplicationStarted) {
+        logg.info { "environment.monitor.subscribe(ApplicationStarted)" }
+        RunOnStart().importNavn()
+    }
 }
 
 fun Application.setupRoutes() {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingModel.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingModel.kt
@@ -65,7 +65,8 @@ data class Delbestilling(
     val serienr: Serienr,
     val deler: List<DelLinje>,
     val levering: Levering,
-    val harOpplæringPåBatteri: Boolean?
+    val harOpplæringPåBatteri: Boolean?,
+    val navn: String?,
 )
 
 data class DelbestillingResultat(

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
@@ -161,7 +161,7 @@ class DelbestillingRepository(val ds: DataSource) {
 
 }
 
-public fun Row.toLagretDelbestilling() = LagretDelbestilling(
+private fun Row.toLagretDelbestilling() = LagretDelbestilling(
     this.long("saksnummer"),
     this.json("delbestilling_json"),
     this.localDateTime("opprettet"),

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
@@ -49,6 +49,17 @@ class DelbestillingRepository(val ds: DataSource) {
         )
     }
 
+    fun hentDelbestillinger(tx: Session): List<LagretDelbestilling> = using(sessionOf(ds)) { session ->
+        tx.run(
+            queryOf(
+                """
+                    SELECT * 
+                    FROM delbestilling
+                """.trimIndent()
+            ).map { it.toLagretDelbestilling() }.asList
+        )
+    }
+
     fun hentDelbestillinger(bestillerFnr: String): List<LagretDelbestilling> = using(sessionOf(ds)) { session ->
         session.run(
             queryOf(

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
@@ -134,7 +134,7 @@ class DelbestillingRepository(val ds: DataSource) {
 
 }
 
-private fun Row.toLagretDelbestilling() = LagretDelbestilling(
+public fun Row.toLagretDelbestilling() = LagretDelbestilling(
     this.long("saksnummer"),
     this.json("delbestilling_json"),
     this.localDateTime("opprettet"),

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
@@ -143,7 +143,7 @@ class DelbestillingRepository(val ds: DataSource) {
         throw e
     }
 
-    fun oppdaterDelbestillingMedNavn(tx: Session, saksnummer: Long, delbestilling: Delbestilling) = try {
+    fun oppdaterDelbestillingUtenSistOppdatert(tx: Session, saksnummer: Long, delbestilling: Delbestilling) = try {
         tx.run(
             queryOf(
                 """

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
@@ -143,6 +143,22 @@ class DelbestillingRepository(val ds: DataSource) {
         throw e
     }
 
+    fun oppdaterDelbestillingMedNavn(tx: Session, saksnummer: Long, delbestilling: Delbestilling) = try {
+        tx.run(
+            queryOf(
+                """
+                UPDATE delbestilling
+                SET delbestilling_json = :delbestilling_json
+                WHERE saksnummer = :saksnummer
+                """.trimIndent(),
+                mapOf("delbestilling_json" to pgJsonbOf(delbestilling), "saksnummer" to saksnummer)
+            ).asUpdate
+        )
+    } catch (e: Exception) {
+        log.error(e) { "Oppdatering av delbestilling_json feilet" }
+        throw e
+    }
+
 }
 
 public fun Row.toLagretDelbestilling() = LagretDelbestilling(

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import no.nav.hjelpemidler.delbestilling.Database
 import no.nav.hjelpemidler.delbestilling.delbestilling.DelbestillingRepository
 import no.nav.hjelpemidler.delbestilling.hjelpemidler.HjelpemiddelDeler
-import javax.sql.DataSource
 
 private val logg = KotlinLogging.logger {}
 
@@ -17,20 +16,23 @@ class RunOnStart(
 
             delbestillinger.forEach { lagretDelbestilling ->
                 logg.info { "opprinnelig delbestilling: $lagretDelbestilling" }
+
                 val navnHovedprodukt =
                     HjelpemiddelDeler.hentHjelpemiddelMedDeler(lagretDelbestilling.delbestilling.hmsnr)?.navn
+
                 logg.info { "navnHovedprodukt: $navnHovedprodukt" }
+
                 if (lagretDelbestilling.delbestilling.navn == null && navnHovedprodukt != null) {
                     delbestillingRepository.withTransaction { tx ->
                         val oppdatertDelbestilling = lagretDelbestilling.delbestilling.copy(navn = navnHovedprodukt)
-                        /*
-                        delbestillingRepository.oppdaterDelbestilling(
-                            tx,
-                            lagretDelbestilling.saksnummer,
-                            oppdatertDelbestilling
-                        )
-                         */
-                        logg.info("oppdatertDelbestilling: $oppdatertDelbestilling")
+                        if (lagretDelbestilling.saksnummer == "47".toLong()) {
+                            delbestillingRepository.oppdaterDelbestillingMedNavn(
+                                tx,
+                                lagretDelbestilling.saksnummer,
+                                oppdatertDelbestilling
+                            )
+                            logg.info("Oppdatert delbestilling for saksnummer 47: $oppdatertDelbestilling")
+                        }
                     }
                 }
 

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
@@ -5,13 +5,22 @@ import kotliquery.sessionOf
 import kotliquery.using
 import mu.KotlinLogging
 import no.nav.hjelpemidler.delbestilling.Database
+import no.nav.hjelpemidler.delbestilling.delbestilling.Hjelpemiddel
 import no.nav.hjelpemidler.delbestilling.delbestilling.toLagretDelbestilling
+import no.nav.hjelpemidler.delbestilling.hjelpemidler.HjelpemiddelDeler
 import javax.sql.DataSource
 
 private val logg = KotlinLogging.logger {}
 
 class RunOnStart(private val ds: DataSource = Database.migratedDataSource) {
     fun importNavn() {
+        val linjer = object {}.javaClass.getResourceAsStream("/hjelpemidler.txt")!!.bufferedReader().readLines()
+
+        val hjelpemidler = linjer.map { linje ->
+            val (hmsnr, navn, type) = linje.split("|")
+            Hjelpemiddel(hmsnr, navn, type)
+        }
+
         val delbestillinger = using(sessionOf(ds)) { session ->
             session.run(
                 queryOf(
@@ -25,6 +34,8 @@ class RunOnStart(private val ds: DataSource = Database.migratedDataSource) {
 
         delbestillinger.forEach {
             logg.info { it }
+            val navnHovedprodukt = HjelpemiddelDeler.hentHjelpemiddelMedDeler(it.delbestilling.hmsnr)?.navn ?: "Ukjent"
+            logg.info { "navnHovedprodukt: $navnHovedprodukt" }
         }
     }
 }

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
@@ -30,6 +30,7 @@ class RunOnStart(
                 if (lagretDelbestilling.delbestilling.navn == null && navnHovedprodukt != null) {
                     delbestillingRepository.withTransaction { tx ->
                         val oppdatertDelbestilling = lagretDelbestilling.delbestilling.copy(navn = navnHovedprodukt)
+                        // TODO: for debugging, må fjernes før merges til prod
                         val oppdaterSaksnummer = "46"
                         if (lagretDelbestilling.saksnummer == oppdaterSaksnummer.toLong()) {
                             delbestillingRepository.oppdaterDelbestillingUtenSistOppdatert(

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
@@ -1,0 +1,30 @@
+package no.nav.hjelpemidler.delbestilling.roller
+
+import kotliquery.queryOf
+import kotliquery.sessionOf
+import kotliquery.using
+import mu.KotlinLogging
+import no.nav.hjelpemidler.delbestilling.Database
+import no.nav.hjelpemidler.delbestilling.delbestilling.toLagretDelbestilling
+import javax.sql.DataSource
+
+private val logg = KotlinLogging.logger {}
+
+class RunOnStart(private val ds: DataSource = Database.migratedDataSource) {
+    fun importNavn() {
+        val delbestillinger = using(sessionOf(ds)) { session ->
+            session.run(
+                queryOf(
+                    """
+                    SELECT * 
+                    FROM delbestilling
+                    """.trimIndent(),
+                ).map { it.toLagretDelbestilling() }.asList
+            )
+        }
+
+        delbestillinger.forEach {
+            logg.info { it }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import no.nav.hjelpemidler.delbestilling.Database
 import no.nav.hjelpemidler.delbestilling.delbestilling.DelbestillingRepository
 import no.nav.hjelpemidler.delbestilling.hjelpemidler.HjelpemiddelDeler
-import kotlin.math.log
 
 private val logg = KotlinLogging.logger {}
 
@@ -17,12 +16,12 @@ class RunOnStart(
 
             var antallOppdaterteRader = 0
             delbestillinger.forEach { lagretDelbestilling ->
-                //logg.info { "opprinnelig delbestilling: $lagretDelbestilling" }
+                // logg.info { "opprinnelig delbestilling: $lagretDelbestilling" }
 
                 val navnHovedprodukt =
                     HjelpemiddelDeler.hentHjelpemiddelMedDeler(lagretDelbestilling.delbestilling.hmsnr)?.navn
 
-                //logg.info { "navnHovedprodukt: $navnHovedprodukt" }
+                // logg.info { "navnHovedprodukt: $navnHovedprodukt" }
 
                 if (navnHovedprodukt == null) {
                     logg.info { "Klarte ikke å finne navn for ${lagretDelbestilling.delbestilling.hmsnr}" }
@@ -31,13 +30,14 @@ class RunOnStart(
                 if (lagretDelbestilling.delbestilling.navn == null && navnHovedprodukt != null) {
                     delbestillingRepository.withTransaction { tx ->
                         val oppdatertDelbestilling = lagretDelbestilling.delbestilling.copy(navn = navnHovedprodukt)
-                        if (lagretDelbestilling.saksnummer == "47".toLong()) {
-                            delbestillingRepository.oppdaterDelbestillingMedNavn(
+                        val oppdaterSaksnummer = "46"
+                        if (lagretDelbestilling.saksnummer == oppdaterSaksnummer.toLong()) {
+                            delbestillingRepository.oppdaterDelbestillingUtenSistOppdatert(
                                 tx,
                                 lagretDelbestilling.saksnummer,
                                 oppdatertDelbestilling
                             )
-                            logg.info("Oppdatert delbestilling for saksnummer 47: $oppdatertDelbestilling")
+                            logg.info("Oppdatert delbestilling for saksnummer $oppdaterSaksnummer: $oppdatertDelbestilling")
                             antallOppdaterteRader++
                         }
                     }

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/roller/RunOnStart.kt
@@ -9,7 +9,6 @@ import javax.sql.DataSource
 private val logg = KotlinLogging.logger {}
 
 class RunOnStart(
-    private val ds: DataSource = Database.migratedDataSource,
     private val delbestillingRepository: DelbestillingRepository = DelbestillingRepository(Database.migratedDataSource),
 ) {
     suspend fun importNavn() {
@@ -32,7 +31,6 @@ class RunOnStart(
                         )
                          */
                         logg.info("oppdatertDelbestilling: $oppdatertDelbestilling")
-
                     }
                 }
 

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/TestHelpers.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/TestHelpers.kt
@@ -28,7 +28,7 @@ fun delbestillingRequest(
         deler = deler,
         levering = Levering.TIL_XK_LAGER,
         harOpplæringPåBatteri = harOpplæringPåBatteri,
-        navn = null
+        navn = "Panthera U3 Light"
     )
 )
 

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/TestHelpers.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/TestHelpers.kt
@@ -27,7 +27,8 @@ fun delbestillingRequest(
         serienr = "687273",
         deler = deler,
         levering = Levering.TIL_XK_LAGER,
-        harOpplæringPåBatteri = harOpplæringPåBatteri
+        harOpplæringPåBatteri = harOpplæringPåBatteri,
+        navn = null
     )
 )
 


### PR DESCRIPTION
Vi vil i de nye [skissene](https://www.figma.com/file/X26HMdUfkTEeZTRIXZzjDS/Bestille-deler?type=design&node-id=817-11928&mode=design&t=NpXgmsdRnDJtfDMG-4) vise frem navnet på hovedproduktet i listen over tidligere bestillinger. Vi sender derimot ikke navnet på hovedproduktet med i delbestillingen fra frontend idag, så vi har det ikke lagret i databasen. 

Dette er et forsøk på å automatisk sette produktnavn utifra hmsnr på hovedproduktet, som en jobb som kjører på oppstart. Vi vil senere sende med produktnavnet i requestet fra frontend, så dette lagres med delbestillingen når den kommer inn.