### PR TITLE
Lagre kommunenavn

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,7 +8,7 @@ on:
       - "CODEOWNERS"
     branches:
       - main
-      - import-navn
+      - hent-kommunenavn
 
 jobs:
   build-and-deploy:

--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -38,6 +38,7 @@ spec:
       rules:
         - application: hm-oebs-api-proxy
         - application: hm-roller
+        - application: digihot-oppslag
       external:
         - host: kafka-schema-registry.nais-q.adeo.no
         - host: hm-oebs-api-proxy.dev-fss-pub.nais.io
@@ -73,3 +74,7 @@ spec:
       value: https://pdl-api.dev-fss-pub.nais.io/graphql
     - name: PDL_API_SCOPE
       value: api://dev-fss.pdl.pdl-api/.default
+    - name: OPPSLAG_API_URL
+      value: http://digihot-oppslag.teamdigihot.svc.cluster.local
+    - name: OPPSLAG_API_SCOPE
+      value: dev-gcp:teamdigihot:digihot-oppslag

--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -76,5 +76,3 @@ spec:
       value: api://dev-fss.pdl.pdl-api/.default
     - name: OPPSLAG_API_URL
       value: http://digihot-oppslag.teamdigihot.svc.cluster.local
-    - name: OPPSLAG_API_SCOPE
-      value: dev-gcp:teamdigihot:digihot-oppslag

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -38,6 +38,7 @@ spec:
       rules:
         - application: hm-oebs-api-proxy
         - application: hm-roller
+        - application: digihot-oppslag
       external:
         - host: kafka-schema-registry.nais.adeo.no
         - host: hm-oebs-api-proxy.prod-fss-pub.nais.io
@@ -73,3 +74,5 @@ spec:
       value: https://pdl-api.prod-fss-pub.nais.io/graphql
     - name: PDL_API_SCOPE
       value: api://prod-fss.pdl.pdl-api/.default
+    - name: OPPSLAG_API_URL
+      value: http://digihot-oppslag.teamdigihot.svc.cluster.local

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/AppContext.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/AppContext.kt
@@ -9,6 +9,8 @@ import no.nav.hjelpemidler.delbestilling.metrics.Metrics
 import no.nav.hjelpemidler.delbestilling.oebs.OebsApiProxyClient
 import no.nav.hjelpemidler.delbestilling.oebs.OebsService
 import no.nav.hjelpemidler.delbestilling.oebs.OebsSinkClient
+import no.nav.hjelpemidler.delbestilling.oppslag.OppslagClient
+import no.nav.hjelpemidler.delbestilling.oppslag.OppslagService
 import no.nav.hjelpemidler.delbestilling.pdl.PdlClient
 import no.nav.hjelpemidler.delbestilling.pdl.PdlService
 import no.nav.hjelpemidler.delbestilling.roller.RolleClient
@@ -16,7 +18,6 @@ import no.nav.hjelpemidler.delbestilling.roller.RolleService
 import no.nav.hjelpemidler.http.openid.azureADClient
 import no.nav.tms.token.support.tokendings.exchange.TokendingsServiceBuilder
 import kotlin.time.Duration.Companion.seconds
-
 
 private val logger = KotlinLogging.logger {}
 
@@ -32,6 +33,8 @@ class AppContext {
     private val rolleClient = RolleClient(tokendingsService)
 
     private val oebsApiProxyClient = OebsApiProxyClient(azureClient)
+
+    private val oppslagClient = OppslagClient(azureClient)
 
     private val kafkaService = KafkaService()
 
@@ -49,6 +52,8 @@ class AppContext {
 
     private val oebsService = OebsService(oebsApiProxyClient, oebsSinkClient)
 
+    private val oppslagService = OppslagService(oppslagClient)
+
     val rolleService = RolleService(rolleClient)
 
     val delbestillingService = DelbestillingService(
@@ -56,6 +61,7 @@ class AppContext {
         pdlService,
         oebsService,
         rolleService,
+        oppslagService,
         metrics
     )
 

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/AppContext.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/AppContext.kt
@@ -34,7 +34,7 @@ class AppContext {
 
     private val oebsApiProxyClient = OebsApiProxyClient(azureClient)
 
-    private val oppslagClient = OppslagClient(azureClient)
+    private val oppslagClient = OppslagClient()
 
     private val kafkaService = KafkaService()
 

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/Config.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/Config.kt
@@ -21,6 +21,10 @@ object Config {
     val ROLLER_API_URL by EnvironmentVariable
     val ROLLER_API_SCOPE by EnvironmentVariable
 
+    // Oppslag
+    val OPPSLAG_API_URL by EnvironmentVariable
+    val OPPSLAG_API_SCOPE by EnvironmentVariable
+
     // Kafka
     val kafkaProducerProperties: Properties by lazy {
         when (NaisEnvironmentVariable.NAIS_CLUSTER_NAME) {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/Config.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/Config.kt
@@ -23,7 +23,6 @@ object Config {
 
     // Oppslag
     val OPPSLAG_API_URL by EnvironmentVariable
-    val OPPSLAG_API_SCOPE by EnvironmentVariable
 
     // Kafka
     val kafkaProducerProperties: Properties by lazy {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
@@ -30,13 +30,14 @@ class DelbestillingRepository(val ds: DataSource) {
         brukerFnr: String,
         brukerKommunenr: String,
         delbestilling: Delbestilling,
+        brukersKommunenavn: String,
     ): Long? {
         log.info { "Lagrer delbestilling '${delbestilling.id}'" }
         return tx.run(
             queryOf(
                 """
-                    INSERT INTO delbestilling (brukers_kommunenr, fnr_bruker, fnr_bestiller, delbestilling_json, status)
-                    VALUES (:brukers_kommunenr, :fnr_bruker, :fnr_bestiller, :delbestilling_json::jsonb, :status)
+                    INSERT INTO delbestilling (brukers_kommunenr, fnr_bruker, fnr_bestiller, delbestilling_json, status, brukers_kommunenavn)
+                    VALUES (:brukers_kommunenr, :fnr_bruker, :fnr_bestiller, :delbestilling_json::jsonb, :status, :brukers_kommunenavn)
                 """.trimIndent(),
                 mapOf(
                     "brukers_kommunenr" to brukerKommunenr,
@@ -44,6 +45,7 @@ class DelbestillingRepository(val ds: DataSource) {
                     "fnr_bestiller" to bestillerFnr,
                     "delbestilling_json" to jsonMapper.writeValueAsString(delbestilling),
                     "status" to Status.INNSENDT.name,
+                    "brukers_kommunenavn" to brukersKommunenavn,
                 ),
             ).asUpdateAndReturnGeneratedKey
         )

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
@@ -70,9 +70,8 @@ class DelbestillingService(
             oppslagService.hentKommune(brukerKommunenr).kommunenavn
         } catch (e: Exception) {
             // Svelg feil, kommunenavn brukes bare til statistikk så ikke krise hvis den feiler
+            "Ukjent"
         }
-
-        log.info { "brukersKommunenavn: $brukersKommunenavn" }
 
         // Det skal ikke være mulig å bestille til seg selv (disabler i dev pga testdata)
         if (isProd() && bestillerFnr == brukersFnr) {
@@ -111,7 +110,8 @@ class DelbestillingService(
                 bestillerFnr,
                 brukersFnr,
                 brukerKommunenr,
-                request.delbestilling
+                request.delbestilling,
+                brukersKommunenavn,
             )
             oebsService.sendDelbestilling(
                 OpprettBestillingsordreRequest(

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
@@ -1,0 +1,60 @@
+package no.nav.hjelpemidler.delbestilling.oppslag
+
+import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import mu.KotlinLogging
+import no.nav.hjelpemidler.delbestilling.Config
+import no.nav.hjelpemidler.delbestilling.navCorrelationId
+import no.nav.hjelpemidler.http.createHttpClient
+import no.nav.hjelpemidler.http.openid.OpenIDClient
+import no.nav.hjelpemidler.http.openid.bearerAuth
+
+private val log = KotlinLogging.logger { }
+
+class OppslagClient(
+    private val azureAdClient: OpenIDClient,
+    engine: HttpClientEngine = CIO.create(),
+    private val url: String = Config.OPPSLAG_API_URL,
+    private val apiScope: String = Config.OPPSLAG_API_SCOPE,
+) {
+    private val client = createHttpClient(engine = engine) {
+        expectSuccess = true
+        defaultRequest {
+            accept(ContentType.Application.Json)
+            contentType(ContentType.Application.Json)
+        }
+    }
+
+    suspend fun hentKommune(kommunenr: String): KommuneDto {
+        return try {
+            withContext(Dispatchers.IO) {
+                val tokenSet = azureAdClient.grant(apiScope)
+                client.get("$url/api/geografi/kommuner/$kommunenr") {
+                    bearerAuth(tokenSet)
+                    headers {
+                        navCorrelationId()
+                    }
+                }.body()
+            }
+        } catch (e: Exception) {
+            log.warn(e) { "Klarte ikke å hente brukers kommune" }
+            throw e
+        }
+    }
+}
+
+data class KommuneDto(
+    val fylkesnummer: String,
+    val fylkesnavn: String,
+    val kommunenummer: String,
+    val kommunenavn: String,
+)

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
@@ -37,9 +37,9 @@ class OppslagClient(
     suspend fun hentKommune(kommunenr: String): KommuneDto {
         return try {
             withContext(Dispatchers.IO) {
-                val tokenSet = azureAdClient.grant(apiScope)
+                // val tokenSet = azureAdClient.grant(apiScope)
                 client.get("$url/api/geografi/kommuner/$kommunenr") {
-                    bearerAuth(tokenSet)
+                    // bearerAuth(tokenSet)
                     headers {
                         navCorrelationId()
                     }

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
@@ -16,7 +16,6 @@ import no.nav.hjelpemidler.delbestilling.Config
 import no.nav.hjelpemidler.delbestilling.navCorrelationId
 import no.nav.hjelpemidler.http.createHttpClient
 import no.nav.hjelpemidler.http.openid.OpenIDClient
-import no.nav.hjelpemidler.http.openid.bearerAuth
 
 private val log = KotlinLogging.logger { }
 
@@ -24,7 +23,6 @@ class OppslagClient(
     private val azureAdClient: OpenIDClient,
     engine: HttpClientEngine = CIO.create(),
     private val url: String = Config.OPPSLAG_API_URL,
-    private val apiScope: String = Config.OPPSLAG_API_SCOPE,
 ) {
     private val client = createHttpClient(engine = engine) {
         expectSuccess = true
@@ -37,16 +35,14 @@ class OppslagClient(
     suspend fun hentKommune(kommunenr: String): KommuneDto {
         return try {
             withContext(Dispatchers.IO) {
-                // val tokenSet = azureAdClient.grant(apiScope)
                 client.get("$url/api/geografi/kommuner/$kommunenr") {
-                    // bearerAuth(tokenSet)
                     headers {
                         navCorrelationId()
                     }
                 }.body()
             }
         } catch (e: Exception) {
-            log.warn(e) { "Klarte ikke å hente brukers kommune" }
+            log.warn(e) { "Klarte ikke å hente brukers kommune for kommunenr: $kommunenr" }
             throw e
         }
     }

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
@@ -15,12 +15,10 @@ import mu.KotlinLogging
 import no.nav.hjelpemidler.delbestilling.Config
 import no.nav.hjelpemidler.delbestilling.navCorrelationId
 import no.nav.hjelpemidler.http.createHttpClient
-import no.nav.hjelpemidler.http.openid.OpenIDClient
 
 private val log = KotlinLogging.logger { }
 
 class OppslagClient(
-    private val azureAdClient: OpenIDClient,
     engine: HttpClientEngine = CIO.create(),
     private val url: String = Config.OPPSLAG_API_URL,
 ) {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagClient.kt
@@ -40,7 +40,7 @@ class OppslagClient(
                 }.body()
             }
         } catch (e: Exception) {
-            log.warn(e) { "Klarte ikke å hente brukers kommune for kommunenr: $kommunenr" }
+            log.warn(e) { "Klarte ikke å hente kommune for kommunenr: $kommunenr" }
             throw e
         }
     }

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/OppslagService.kt
@@ -1,0 +1,11 @@
+package no.nav.hjelpemidler.delbestilling.oppslag
+
+class OppslagService(private val oppslagClient: OppslagClient) {
+    suspend fun hentKommune(kommunenr: String): KommuneDto {
+        try {
+            return oppslagClient.hentKommune(kommunenr)
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+}

--- a/src/main/resources/db/migration/V6__add_brukers_kommunenavn.sql
+++ b/src/main/resources/db/migration/V6__add_brukers_kommunenavn.sql
@@ -1,0 +1,10 @@
+ALTER TABLE delbestilling ADD COLUMN brukers_kommunenavn VARCHAR(255);
+
+UPDATE delbestilling
+SET brukers_kommunenavn = CASE
+    WHEN brukers_kommunenr = '5433' THEN 'Hasvik' -- kun for dev
+    WHEN brukers_kommunenr = '0301' THEN 'Oslo'
+    WHEN brukers_kommunenr = '3034' THEN 'Nes'
+    WHEN brukers_kommunenr = '3024' THEN 'Bærum'
+    ELSE 'Ukjent'
+END;

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/TestHelpers.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/TestHelpers.kt
@@ -5,6 +5,7 @@ import no.nav.hjelpemidler.delbestilling.delbestilling.DelLinje
 import no.nav.hjelpemidler.delbestilling.delbestilling.Delbestilling
 import no.nav.hjelpemidler.delbestilling.delbestilling.DelbestillingRequest
 import no.nav.hjelpemidler.delbestilling.delbestilling.Levering
+import no.nav.hjelpemidler.delbestilling.oppslag.KommuneDto
 import no.nav.hjelpemidler.delbestilling.roller.Delbestiller
 import no.nav.hjelpemidler.delbestilling.roller.Organisasjon
 import java.util.UUID
@@ -47,6 +48,13 @@ fun delLinje(antall: Int = 1, hmsnr: String = "150817", kategori: String = "Dekk
         maksAntall = 2,
     ),
     antall = antall,
+)
+
+fun kommune() = KommuneDto(
+    fylkesnummer = "3",
+    fylkesnavn = "Oslo",
+    kommunenavn = "0301",
+    kommunenummer = "Oslo",
 )
 
 class MockException(msg: String) : RuntimeException("MockException: $msg")

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/TestHelpers.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/TestHelpers.kt
@@ -53,8 +53,8 @@ fun delLinje(antall: Int = 1, hmsnr: String = "150817", kategori: String = "Dekk
 fun kommune() = KommuneDto(
     fylkesnummer = "3",
     fylkesnavn = "Oslo",
-    kommunenavn = "0301",
-    kommunenummer = "Oslo",
+    kommunenavn = "Oslo",
+    kommunenummer = "0301",
 )
 
 class MockException(msg: String) : RuntimeException("MockException: $msg")

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingServiceTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingServiceTest.kt
@@ -10,9 +10,11 @@ import no.nav.hjelpemidler.delbestilling.MockException
 import no.nav.hjelpemidler.delbestilling.TestDatabase
 import no.nav.hjelpemidler.delbestilling.delbestillerRolle
 import no.nav.hjelpemidler.delbestilling.delbestillingRequest
+import no.nav.hjelpemidler.delbestilling.kommune
 import no.nav.hjelpemidler.delbestilling.oebs.OebsPersoninfo
 import no.nav.hjelpemidler.delbestilling.oebs.OebsService
 import no.nav.hjelpemidler.delbestilling.oebs.OpprettBestillingsordreRequest
+import no.nav.hjelpemidler.delbestilling.oppslag.OppslagService
 import no.nav.hjelpemidler.delbestilling.pdl.PdlService
 import no.nav.hjelpemidler.delbestilling.roller.RolleService
 import org.junit.jupiter.api.BeforeEach
@@ -42,8 +44,11 @@ internal class DelbestillingServiceTest {
     private val rolleService = mockk<RolleService>(relaxed = true).apply {
         coEvery { hentDelbestillerRolle(any()) } returns delbestillerRolle()
     }
+    private val oppslagService = mockk<OppslagService>(relaxed = true).apply {
+        coEvery { hentKommune(any()) } returns kommune()
+    }
     private val delbestillingService =
-        DelbestillingService(delbestillingRepository, pdlService, oebsService, rolleService, mockk(relaxed = true))
+        DelbestillingService(delbestillingRepository, pdlService, oebsService, rolleService, oppslagService, mockk(relaxed = true))
 
     @BeforeEach
     fun setup() {


### PR DESCRIPTION
Vi vil gjerne vise frem brukers kommunenavn i statistikken vår i Metabase, men vi har ikke dette idag (vi lagrer kun kommunenr). Denne PRen legger til kolonnen `brukers_kommunenavn` i databasen, og setter verdiene for eksisterende rader. Når nye delbestillinger kommer inn, gjøres det kall mot digihot-oppslag for å hente kommunenavn basert på kommunenr.