### PR TITLE
Returner lagret delbestilling i respons ved innsending

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,7 +8,7 @@ on:
       - "CODEOWNERS"
     branches:
       - main
-      - distroless
+      - returner-delbestilling
 
 jobs:
   build-and-deploy:

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingModel.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingModel.kt
@@ -76,6 +76,7 @@ data class DelbestillingResultat(
     val id: UUID,
     val feil: DelbestillingFeil? = null,
     val saksnummer: Long? = null,
+    val lagretDelbestilling: LagretDelbestilling?,
 )
 
 enum class DelbestillingFeil {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingModel.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingModel.kt
@@ -76,7 +76,7 @@ data class DelbestillingResultat(
     val id: UUID,
     val feil: DelbestillingFeil? = null,
     val saksnummer: Long? = null,
-    val delbestillingSak: DelbestillingSak?,
+    val delbestillingSak: DelbestillingSak? = null,
 )
 
 enum class DelbestillingFeil {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingModel.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingModel.kt
@@ -76,7 +76,7 @@ data class DelbestillingResultat(
     val id: UUID,
     val feil: DelbestillingFeil? = null,
     val saksnummer: Long? = null,
-    val lagretDelbestilling: LagretDelbestilling?,
+    val delbestillingSak: DelbestillingSak?,
 )
 
 enum class DelbestillingFeil {
@@ -89,7 +89,7 @@ enum class DelbestillingFeil {
     FOR_MANGE_BESTILLINGER_SISTE_24_TIMER,
 }
 
-data class LagretDelbestilling(
+data class DelbestillingSak(
     val saksnummer: Long,
     val delbestilling: Delbestilling,
     val opprettet: LocalDateTime,

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
@@ -75,7 +75,7 @@ class DelbestillingRepository(val ds: DataSource) {
         )
     }
 
-    fun hentDelbestilling(saksnummer: Long, tx: Session = sessionOf(ds)): DelbestillingSak? = tx.run(
+    fun hentDelbestilling(tx: Session, saksnummer: Long): DelbestillingSak? = tx.run(
         queryOf(
             """
                 SELECT * 

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
@@ -51,7 +51,7 @@ class DelbestillingRepository(val ds: DataSource) {
         )
     }
 
-    fun hentDelbestillinger(tx: Session): List<LagretDelbestilling> = using(sessionOf(ds)) { session ->
+    fun hentDelbestillinger(tx: Session): List<DelbestillingSak> = using(sessionOf(ds)) { session ->
         tx.run(
             queryOf(
                 """
@@ -62,7 +62,7 @@ class DelbestillingRepository(val ds: DataSource) {
         )
     }
 
-    fun hentDelbestillinger(bestillerFnr: String): List<LagretDelbestilling> = using(sessionOf(ds)) { session ->
+    fun hentDelbestillinger(bestillerFnr: String): List<DelbestillingSak> = using(sessionOf(ds)) { session ->
         session.run(
             queryOf(
                 """
@@ -75,7 +75,7 @@ class DelbestillingRepository(val ds: DataSource) {
         )
     }
 
-    fun hentDelbestilling(tx: Session, saksnummer: Long): LagretDelbestilling? = tx.run(
+    fun hentDelbestilling(tx: Session, saksnummer: Long): DelbestillingSak? = tx.run(
         queryOf(
             """
                 SELECT * 
@@ -86,7 +86,7 @@ class DelbestillingRepository(val ds: DataSource) {
         ).map { it.toLagretDelbestilling() }.asSingle
     )
 
-    fun hentDelbestilling(tx: Session, oebsOrdrenummer: String): LagretDelbestilling? = tx.run(
+    fun hentDelbestilling(tx: Session, oebsOrdrenummer: String): DelbestillingSak? = tx.run(
         queryOf(
             """
                 SELECT * 
@@ -163,7 +163,7 @@ class DelbestillingRepository(val ds: DataSource) {
 
 }
 
-private fun Row.toLagretDelbestilling() = LagretDelbestilling(
+private fun Row.toLagretDelbestilling() = DelbestillingSak(
     this.long("saksnummer"),
     this.json("delbestilling_json"),
     this.localDateTime("opprettet"),

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingRepository.kt
@@ -75,7 +75,7 @@ class DelbestillingRepository(val ds: DataSource) {
         )
     }
 
-    fun hentDelbestilling(tx: Session, saksnummer: Long): DelbestillingSak? = tx.run(
+    fun hentDelbestilling(saksnummer: Long, tx: Session = sessionOf(ds)): DelbestillingSak? = tx.run(
         queryOf(
             """
                 SELECT * 

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
@@ -138,11 +138,8 @@ class DelbestillingService(
 
         sendStatistikk(request.delbestilling, utlån.fnr)
 
-        // Hent ut den nye delbestillingen
         val delbestillingSak = if (lagretSaksnummer != null) {
-            delbestillingRepository.withTransaction { tx ->
-                delbestillingRepository.hentDelbestilling(tx, lagretSaksnummer)
-            }
+            delbestillingRepository.hentDelbestilling(lagretSaksnummer)
         } else {
             null
         }
@@ -173,7 +170,7 @@ class DelbestillingService(
 
     suspend fun oppdaterStatus(saksnummer: Long, status: Status, oebsOrdrenummer: String) {
         delbestillingRepository.withTransaction { tx ->
-            val lagretDelbestilling = delbestillingRepository.hentDelbestilling(tx, saksnummer)!!
+            val lagretDelbestilling = delbestillingRepository.hentDelbestilling(saksnummer, tx)!!
 
             if (lagretDelbestilling.oebsOrdrenummer == null) {
                 delbestillingRepository.oppdaterOebsOrdrenummer(tx, saksnummer, oebsOrdrenummer)

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
@@ -139,7 +139,7 @@ class DelbestillingService(
         sendStatistikk(request.delbestilling, utlån.fnr)
 
         // Hent ut den nye delbestillingen
-        val lagretDelbestilling = if (lagretSaksnummer != null) {
+        val delbestillingSak = if (lagretSaksnummer != null) {
             delbestillingRepository.withTransaction { tx ->
                 delbestillingRepository.hentDelbestilling(tx, lagretSaksnummer)
             }
@@ -147,7 +147,7 @@ class DelbestillingService(
             null
         }
 
-        return DelbestillingResultat(id, null, saksnummer = lagretSaksnummer, lagretDelbestilling)
+        return DelbestillingResultat(id, null, lagretSaksnummer, delbestillingSak)
     }
 
     suspend fun sendStatistikk(delbestilling: Delbestilling, fnrBruker: String) = coroutineScope {
@@ -265,7 +265,7 @@ class DelbestillingService(
         return OppslagResultat(hjelpemiddelMedDeler, null, HttpStatusCode.OK)
     }
 
-    fun hentDelbestillinger(bestillerFnr: String): List<LagretDelbestilling> {
+    fun hentDelbestillinger(bestillerFnr: String): List<DelbestillingSak> {
         return delbestillingRepository.hentDelbestillinger(bestillerFnr)
     }
 }

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
@@ -138,8 +138,11 @@ class DelbestillingService(
 
         sendStatistikk(request.delbestilling, utlån.fnr)
 
+        // Hent ut den nye delbestillingen
         val delbestillingSak = if (lagretSaksnummer != null) {
-            delbestillingRepository.hentDelbestilling(lagretSaksnummer)
+            delbestillingRepository.withTransaction { tx ->
+                delbestillingRepository.hentDelbestilling(tx, lagretSaksnummer)
+            }
         } else {
             null
         }
@@ -170,7 +173,7 @@ class DelbestillingService(
 
     suspend fun oppdaterStatus(saksnummer: Long, status: Status, oebsOrdrenummer: String) {
         delbestillingRepository.withTransaction { tx ->
-            val lagretDelbestilling = delbestillingRepository.hentDelbestilling(saksnummer, tx)!!
+            val lagretDelbestilling = delbestillingRepository.hentDelbestilling(tx, saksnummer)!!
 
             if (lagretDelbestilling.oebsOrdrenummer == null) {
                 delbestillingRepository.oppdaterOebsOrdrenummer(tx, saksnummer, oebsOrdrenummer)

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
@@ -50,14 +50,14 @@ class DelbestillingService(
 
         val feil = validerDelbestillingRate(bestillerFnr, hmsnr, serienr)
         if (feil != null) {
-            return DelbestillingResultat(id, feil = feil)
+            return DelbestillingResultat(id, feil = feil, null, null)
         }
 
         val levering = request.delbestilling.levering
         val deler = request.delbestilling.deler
 
         val utlån = oebsService.hentUtlånPåArtnrOgSerienr(hmsnr, serienr)
-            ?: return DelbestillingResultat(id, feil = DelbestillingFeil.INGET_UTLÅN)
+            ?: return DelbestillingResultat(id, feil = DelbestillingFeil.INGET_UTLÅN, null, null)
 
         val brukersFnr = utlån.fnr
 
@@ -65,10 +65,10 @@ class DelbestillingService(
             pdlService.hentKommunenummer(brukersFnr)
         } catch (e: PersonNotAccessibleInPdl) {
             log.error(e) { "Person ikke tilgjengelig i PDL" }
-            return DelbestillingResultat(id, feil = DelbestillingFeil.KAN_IKKE_BESTILLE)
+            return DelbestillingResultat(id, feil = DelbestillingFeil.KAN_IKKE_BESTILLE, null, null)
         } catch (e: PersonNotFoundInPdl) {
             log.error(e) { "Person ikke funnet i PDL" }
-            return DelbestillingResultat(id, feil = DelbestillingFeil.BRUKER_IKKE_FUNNET)
+            return DelbestillingResultat(id, feil = DelbestillingFeil.BRUKER_IKKE_FUNNET, null, null)
         } catch (e: Exception) {
             log.error(e) { "Klarte ikke å hente bruker fra PDL" }
             throw e
@@ -84,7 +84,7 @@ class DelbestillingService(
         // Det skal ikke være mulig å bestille til seg selv (disabler i dev pga testdata)
         if (isProd() && bestillerFnr == brukersFnr) {
             log.info { "Bestiller prøver å bestille til seg selv" }
-            return DelbestillingResultat(id, feil = DelbestillingFeil.BESTILLE_TIL_SEG_SELV)
+            return DelbestillingResultat(id, feil = DelbestillingFeil.BESTILLE_TIL_SEG_SELV, null, null)
         }
 
         // Sjekk at PDL og OEBS kommunenr på bruker stemmer overens
@@ -92,7 +92,7 @@ class DelbestillingService(
         val brukerHarSammeKommunenrIOebsOgPdl = oebsBrukerinfo.any { it.leveringKommune == brukerKommunenr }
         if (!brukerHarSammeKommunenrIOebsOgPdl) {
             log.info { "Ulik leveringsadresse. OEBS: $oebsBrukerinfo, PDL: $brukerKommunenr" }
-            return DelbestillingResultat(id, feil = DelbestillingFeil.ULIK_ADRESSE_PDL_OEBS)
+            return DelbestillingResultat(id, feil = DelbestillingFeil.ULIK_ADRESSE_PDL_OEBS, null, null)
         }
 
         // Sjekk om en av innsenders kommuner tilhører brukers kommuner
@@ -104,7 +104,7 @@ class DelbestillingService(
             log.info { "Brukers kommunenr: $brukerKommunenr, innsenders kommuner: ${delbestillerRolle.kommunaleOrgs}" }
             return DelbestillingResultat(
                 id,
-                feil = DelbestillingFeil.ULIK_GEOGRAFISK_TILKNYTNING,
+                feil = DelbestillingFeil.ULIK_GEOGRAFISK_TILKNYTNING, null, null,
             )
         }
 
@@ -138,7 +138,16 @@ class DelbestillingService(
 
         sendStatistikk(request.delbestilling, utlån.fnr)
 
-        return DelbestillingResultat(id, null, saksnummer = lagretSaksnummer)
+        // Hent ut den nye delbestillingen
+        val lagretDelbestilling = if (lagretSaksnummer != null) {
+            delbestillingRepository.withTransaction { tx ->
+                delbestillingRepository.hentDelbestilling(tx, lagretSaksnummer)
+            }
+        } else {
+            null
+        }
+
+        return DelbestillingResultat(id, null, saksnummer = lagretSaksnummer, lagretDelbestilling)
     }
 
     suspend fun sendStatistikk(delbestilling: Delbestilling, fnrBruker: String) = coroutineScope {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingService.kt
@@ -50,14 +50,14 @@ class DelbestillingService(
 
         val feil = validerDelbestillingRate(bestillerFnr, hmsnr, serienr)
         if (feil != null) {
-            return DelbestillingResultat(id, feil = feil, null, null)
+            return DelbestillingResultat(id, feil = feil)
         }
 
         val levering = request.delbestilling.levering
         val deler = request.delbestilling.deler
 
         val utlån = oebsService.hentUtlånPåArtnrOgSerienr(hmsnr, serienr)
-            ?: return DelbestillingResultat(id, feil = DelbestillingFeil.INGET_UTLÅN, null, null)
+            ?: return DelbestillingResultat(id, feil = DelbestillingFeil.INGET_UTLÅN)
 
         val brukersFnr = utlån.fnr
 
@@ -65,10 +65,10 @@ class DelbestillingService(
             pdlService.hentKommunenummer(brukersFnr)
         } catch (e: PersonNotAccessibleInPdl) {
             log.error(e) { "Person ikke tilgjengelig i PDL" }
-            return DelbestillingResultat(id, feil = DelbestillingFeil.KAN_IKKE_BESTILLE, null, null)
+            return DelbestillingResultat(id, feil = DelbestillingFeil.KAN_IKKE_BESTILLE)
         } catch (e: PersonNotFoundInPdl) {
             log.error(e) { "Person ikke funnet i PDL" }
-            return DelbestillingResultat(id, feil = DelbestillingFeil.BRUKER_IKKE_FUNNET, null, null)
+            return DelbestillingResultat(id, feil = DelbestillingFeil.BRUKER_IKKE_FUNNET)
         } catch (e: Exception) {
             log.error(e) { "Klarte ikke å hente bruker fra PDL" }
             throw e
@@ -84,7 +84,7 @@ class DelbestillingService(
         // Det skal ikke være mulig å bestille til seg selv (disabler i dev pga testdata)
         if (isProd() && bestillerFnr == brukersFnr) {
             log.info { "Bestiller prøver å bestille til seg selv" }
-            return DelbestillingResultat(id, feil = DelbestillingFeil.BESTILLE_TIL_SEG_SELV, null, null)
+            return DelbestillingResultat(id, feil = DelbestillingFeil.BESTILLE_TIL_SEG_SELV)
         }
 
         // Sjekk at PDL og OEBS kommunenr på bruker stemmer overens
@@ -92,7 +92,7 @@ class DelbestillingService(
         val brukerHarSammeKommunenrIOebsOgPdl = oebsBrukerinfo.any { it.leveringKommune == brukerKommunenr }
         if (!brukerHarSammeKommunenrIOebsOgPdl) {
             log.info { "Ulik leveringsadresse. OEBS: $oebsBrukerinfo, PDL: $brukerKommunenr" }
-            return DelbestillingResultat(id, feil = DelbestillingFeil.ULIK_ADRESSE_PDL_OEBS, null, null)
+            return DelbestillingResultat(id, feil = DelbestillingFeil.ULIK_ADRESSE_PDL_OEBS)
         }
 
         // Sjekk om en av innsenders kommuner tilhører brukers kommuner
@@ -104,7 +104,7 @@ class DelbestillingService(
             log.info { "Brukers kommunenr: $brukerKommunenr, innsenders kommuner: ${delbestillerRolle.kommunaleOrgs}" }
             return DelbestillingResultat(
                 id,
-                feil = DelbestillingFeil.ULIK_GEOGRAFISK_TILKNYTNING, null, null,
+                feil = DelbestillingFeil.ULIK_GEOGRAFISK_TILKNYTNING,
             )
         }
 


### PR DESCRIPTION
Må ses i sammenheng med PR https://github.com/navikt/hm-delbestilling/pull/37
Tanken er ved å returnere hele den nye delbestillingen, så kan vi bruke den dataen til å vise frem kvitteringen på klienten, fremfor det som lå i handlekurven ved innsending. Det gjør at vi enklere kan gjenbruke `BestillingsKort`-komponenten ved å bare sende inn hele saken som en prop.