### PR TITLE
Map HMS Akershus til HMS Oslo

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -8,6 +8,7 @@ on:
       - "CODEOWNERS"
     branches:
       - main
+      - map-hms-akershus-til-hms-oslo
 
 jobs:
   build:

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/AppContext.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/AppContext.kt
@@ -32,8 +32,8 @@ import no.nav.hjelpemidler.delbestilling.oppslag.BerikMedLagerstatus
 import no.nav.hjelpemidler.delbestilling.oppslag.FinnDelerTilHjelpemiddel
 import no.nav.hjelpemidler.delbestilling.oppslag.OppslagService
 import no.nav.hjelpemidler.delbestilling.ordrestatus.DelbestillingStatusService
-import no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg.Norg
-import no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg.NorgClient
+import no.nav.hjelpemidler.delbestilling.infrastructure.norg.Norg
+import no.nav.hjelpemidler.delbestilling.infrastructure.norg.NorgClient
 import no.nav.hjelpemidler.http.openid.entraIDClient
 import no.nav.tms.token.support.tokendings.exchange.TokendingsServiceBuilder
 import kotlin.time.Duration.Companion.seconds
@@ -55,16 +55,17 @@ class AppContext {
             maximumSize = 100
         }
     }
+    val email = Email(GraphClient(entraIDClient))
+    val slack = Slack(transactional, backgroundScope)
     private val grunndata = Grunndata(GrunndataClient())
     private val kafka = Kafka()
     private val kommuneoppslag = Kommuneoppslag(OppslagClient())
     private val metrics = Metrics(kafka)
-    private val norg = Norg(NorgClient())
+    private val norg = Norg(NorgClient(), slack)
     private val oebs = Oebs(OebsApiProxyClient(entraIDClient), OebsSinkClient(kafka))
     private val pdl = Pdl(PdlClient(entraIDClient))
     private val rollerClient = RollerClient(TokendingsServiceBuilder.buildTokendingsService())
-    val email = Email(GraphClient(entraIDClient))
-    val slack = Slack(transactional, backgroundScope)
+
 
     // Eksponert for custom plugin
     val roller = Roller(rollerClient)

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/AnmodningService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/AnmodningService.kt
@@ -7,7 +7,7 @@ import no.nav.hjelpemidler.delbestilling.infrastructure.grunndata.Grunndata
 import no.nav.hjelpemidler.delbestilling.infrastructure.oebs.Oebs
 import no.nav.hjelpemidler.delbestilling.infrastructure.persistence.transaction.Transactional
 import no.nav.hjelpemidler.delbestilling.infrastructure.slack.Slack
-import no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg.Norg
+import no.nav.hjelpemidler.delbestilling.infrastructure.norg.Norg
 
 private val log = KotlinLogging.logger {}
 
@@ -22,7 +22,7 @@ class AnmodningService(
 
     suspend fun lagreDelerUtenDekning(sak: DelbestillingSak) {
         val delerUtenDekning = finnDelerUtenDekning(sak)
-        val enhetnummer = norg.hentEnhetnummer(sak.brukersKommunenummer)
+        val enhet = norg.hentEnhet(sak.brukersKommunenummer)
 
         log.info { "Dekningsjekk: lagrer følgende deler uten dekning: ${delerUtenDekning.joinToString("\n")}" }
 
@@ -36,12 +36,12 @@ class AnmodningService(
                         antallUtenDekning = del.antallSomMåAnmodes,
                         bukersKommunenummer = sak.brukersKommunenummer,
                         brukersKommunenavn = sak.brukersKommunenavn,
-                        enhetnr = enhetnummer,
+                        enhetnr = enhet.nummer,
                     )
                 }
             }
 
-            slack.varsleOmDelerUtenDekning(delerUtenDekning, sak.brukersKommunenavn, enhetnummer)
+            slack.varsleOmDelerUtenDekning(delerUtenDekning, sak.brukersKommunenavn, enhet.nummer)
         }
     }
 

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/norg/Norg.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/norg/Norg.kt
@@ -1,16 +1,40 @@
-package no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg
+package no.nav.hjelpemidler.delbestilling.infrastructure.norg
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import no.nav.hjelpemidler.delbestilling.infrastructure.norg.NorgClientInterface
+import no.nav.hjelpemidler.delbestilling.common.Enhet
+import no.nav.hjelpemidler.delbestilling.infrastructure.slack.Slack
 
 private val log = KotlinLogging.logger {}
 
-class Norg(private val norgClient: NorgClientInterface) {
-    suspend fun hentEnhetnummer(kommunenummer: String): String {
+class Norg(
+    private val norgClient: NorgClientInterface,
+    private val slack: Slack,
+) {
+
+    private suspend fun hentEnhetnummer(kommunenummer: String): String {
         val enheter = norgClient.hentArbeidsfordelingenheter(kommunenummer)
         if (enheter.size > 1) {
             log.error { "Mottok flere enheter for kommunenummer $kommunenummer: $enheter" }
         }
         return enheter.first().enhetNr
     }
+
+    suspend fun hentEnhet(kommunenummer: String): Enhet {
+        val enhetsnummer = hentEnhetnummer(kommunenummer)
+
+        return try {
+            when (enhetsnummer) {
+                // 4702 = HMS Akershus, men når det gjelder lagerstatus så håndteres dette av Oslo.
+                // I OeBS skal innbyggere her være knyttet til 4703 HMS Oslo
+                ENHETSNUMMER_HMS_AKERSHUS -> Enhet.OSLO
+                else -> Enhet.fraEnhetsnummer(enhetsnummer)
+            }
+        } catch (e: Exception) {
+            log.error(e) { "Klarte ikke finne enhet for kommunenummer $kommunenummer" }
+            slack.varsleOmUkjentEnhet(kommunenummer, enhetsnummer)
+            throw e
+        }
+    }
 }
+
+private const val ENHETSNUMMER_HMS_AKERSHUS = "4702"

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/norg/NorgClient.kt
@@ -1,4 +1,4 @@
-package no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg
+package no.nav.hjelpemidler.delbestilling.infrastructure.norg
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.client.HttpClient
@@ -15,9 +15,8 @@ import kotlinx.coroutines.async
 import no.nav.hjelpemidler.delbestilling.config.AppConfig
 import no.nav.hjelpemidler.delbestilling.infrastructure.defaultHttpClient
 import no.nav.hjelpemidler.delbestilling.infrastructure.navCorrelationId
-import no.nav.hjelpemidler.delbestilling.infrastructure.norg.NorgClientInterface
+import no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg.ArbeidsfordelingEnhet
 import java.util.concurrent.TimeUnit
-
 
 class NorgClient(
     private val client: HttpClient = defaultHttpClient(),

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/slack/Slack.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/slack/Slack.kt
@@ -147,4 +147,9 @@ class Slack(
         message = "Følgende deler med 'batteri' i kategorien sin har blitt bestilt. Vurder om de krever kurs eller skal legges inn som 'håndterteBatterikategorier'. ```${deler.joinToString(separator = "\n")}```"
     )
 
+    fun varsleOmUkjentEnhet(kommunenummer: String, enhetsnummer: String) = sendSafely(
+        emoji = "error",
+        message = "Enhet er ikke definert for enhetsnummer=$enhetsnummer (kommunenummer=$kommunenummer)"
+    )
+
 }

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/PiloterService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/PiloterService.kt
@@ -3,7 +3,7 @@ package no.nav.hjelpemidler.delbestilling.oppslag
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.hjelpemidler.delbestilling.common.Enhet
 import no.nav.hjelpemidler.delbestilling.config.isDev
-import no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg.Norg
+import no.nav.hjelpemidler.delbestilling.infrastructure.norg.Norg
 
 private val log = KotlinLogging.logger { }
 
@@ -21,14 +21,14 @@ private val PILOTENHETER_BESTILLE_IKKE_FASTE_LAGERVARER = setOf(
     Enhet.VESTLAND_FØRDE,
     Enhet.NORDLAND,
     Enhet.INNLANDET_GJØVIK,
-).map { it.nummer }
+)
 
 class PiloterService(
     private val norg: Norg
 ) {
 
     suspend fun hentPiloter(brukersKommunenummer: String): List<Pilot> {
-        val brukersEnhet = norg.hentEnhetnummer(brukersKommunenummer)
+        val brukersEnhet = norg.hentEnhet(brukersKommunenummer)
 
         val piloter =  buildList {
             if (isDev() || PILOTENHETER_BESTILLE_IKKE_FASTE_LAGERVARER.contains(brukersEnhet)) {

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingServiceTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingServiceTest.kt
@@ -18,7 +18,7 @@ import no.nav.hjelpemidler.delbestilling.infrastructure.pdl.Pdl
 import no.nav.hjelpemidler.delbestilling.infrastructure.persistence.transaction.Transaction
 import no.nav.hjelpemidler.delbestilling.infrastructure.persistence.transaction.TransactionScopeFactory
 import no.nav.hjelpemidler.delbestilling.infrastructure.slack.Slack
-import no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg.Norg
+import no.nav.hjelpemidler.delbestilling.infrastructure.norg.Norg
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -118,9 +118,9 @@ internal class DelbestillingServiceTest {
 
     @Test
     fun `skal lagre anmodningsbehov ved ny delbestilling`() = runTest {
-        val enhetnr = Enhet.OSLO.nummer
+        val enhet = Enhet.OSLO
         val norg =
-            mockk<Norg>().also { coEvery { it.hentEnhetnummer(any()) } returns enhetnr }
+            mockk<Norg>().also { coEvery { it.hentEnhet(any()) } returns enhet }
         val anmodningService =
             AnmodningService(
                 transaction,
@@ -171,7 +171,7 @@ internal class DelbestillingServiceTest {
             delbestillerRolle()
         )
 
-        val delerTilRapportering = transaction { delUtenDekningDao.hentDelerTilRapportering(enhetnr) }
+        val delerTilRapportering = transaction { delUtenDekningDao.hentDelerTilRapportering(enhet.nummer) }
         assertEquals(2, delerTilRapportering.size)
         assertEquals(1, delerTilRapportering.find { it.hmsnr == hmsnrEtterfylt }!!.antall)
         assertEquals(2, delerTilRapportering.find { it.hmsnr == hmsnrIkkeDekning }!!.antall)
@@ -189,7 +189,7 @@ internal class DelbestillingServiceTest {
         val anmodninger = delbestillingService.rapporterDelerTilAnmodning().first()
         assertEquals(
             0,
-            transaction { delUtenDekningDao.hentDelerTilRapportering(enhetnr).size },
+            transaction { delUtenDekningDao.hentDelerTilRapportering(enhet.nummer).size },
             "Det skal ikke lenger eksistere deler til rapportering"
         )
         assertEquals(1, anmodninger.anmodningsbehov.size)
@@ -198,11 +198,11 @@ internal class DelbestillingServiceTest {
 
     @Test
     fun `skal summere anmodningsbehov`() = runTest {
-        val enhetnr = Enhet.OSLO.nummer
+        val enhet = Enhet.OSLO
         val hmsnr1 = "111111"
         val hmsnr2 = "222222"
         val norg =
-            mockk<Norg>().also { coEvery { it.hentEnhetnummer(any()) } returns enhetnr }
+            mockk<Norg>().also { coEvery { it.hentEnhet(any()) } returns enhet }
         val anmodningService =
             AnmodningService(
                 transaction,
@@ -256,7 +256,7 @@ internal class DelbestillingServiceTest {
         )
 
         // Sjekk at anmodningsbehov er summert for begge delbestillingene
-        val delerTilRapportering = transaction { delUtenDekningDao.hentDelerTilRapportering(enhetnr) }
+        val delerTilRapportering = transaction { delUtenDekningDao.hentDelerTilRapportering(enhet.nummer) }
         assertEquals(2, delerTilRapportering.size)
         assertEquals(2, delerTilRapportering.find { it.hmsnr == hmsnr1 }!!.antall)
         assertEquals(3, delerTilRapportering.find { it.hmsnr == hmsnr2 }!!.antall)

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/AnmodningServiceTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/AnmodningServiceTest.kt
@@ -12,7 +12,7 @@ import no.nav.hjelpemidler.delbestilling.infrastructure.oebs.Oebs
 import no.nav.hjelpemidler.delbestilling.infrastructure.persistence.transaction.Transaction
 import no.nav.hjelpemidler.delbestilling.infrastructure.persistence.transaction.TransactionScopeFactory
 import no.nav.hjelpemidler.delbestilling.infrastructure.slack.Slack
-import no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg.Norg
+import no.nav.hjelpemidler.delbestilling.infrastructure.norg.Norg
 import org.junit.jupiter.api.Test
 
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/norg/NorgTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/norg/NorgTest.kt
@@ -1,0 +1,19 @@
+package no.nav.hjelpemidler.delbestilling.infrastructure.norg
+
+import no.nav.hjelpemidler.delbestilling.common.Enhet
+import no.nav.hjelpemidler.delbestilling.fakes.NorgResponse
+import no.nav.hjelpemidler.delbestilling.testdata.runWithTestContext
+import no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg.ArbeidsfordelingEnhet
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+class NorgTest {
+
+    @Test
+    fun `enhet 4702 Akershus skal mappes til 4703 Oslo`() = runWithTestContext {
+        norgClient.response = NorgResponse.enhet(enhetNr = "4702")
+        val enhet = norg.hentEnhet("1234")
+        assertEquals(Enhet.OSLO, enhet)
+    }
+}

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/PiloterServiceTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/oppslag/PiloterServiceTest.kt
@@ -27,4 +27,13 @@ class PiloterServiceTest {
 
         assertEquals(emptyList(), piloter)
     }
+
+    @Test
+    fun `skal håndtere gammle enhetsnr`() = runWithTestContext {
+        norgClient.response = NorgResponse.enhet(enhetNr = "4702")
+
+        val piloter = piloterService.hentPiloter("1234")
+
+        assertEquals(listOf(Pilot.BESTILLE_IKKE_FASTE_LAGERVARER), piloter)
+    }
 }

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/TestContext.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/TestContext.kt
@@ -22,7 +22,7 @@ import no.nav.hjelpemidler.delbestilling.oppslag.BerikMedDagerSidenForrigeBatter
 import no.nav.hjelpemidler.delbestilling.oppslag.BerikMedLagerstatus
 import no.nav.hjelpemidler.delbestilling.oppslag.FinnDelerTilHjelpemiddel
 import no.nav.hjelpemidler.delbestilling.oppslag.OppslagService
-import no.nav.hjelpemidler.hjelpemidlerdigitalSoknadapi.tjenester.norg.Norg
+import no.nav.hjelpemidler.delbestilling.infrastructure.norg.Norg
 
 class TestContext {
     // Mocks
@@ -41,7 +41,7 @@ class TestContext {
 
     // Norg
     val norgClient = NorgClientFake()
-    val norg = Norg(norgClient)
+    val norg = Norg(norgClient, slack)
 
     // OeBS
     val lager = FakeOebsLager()


### PR DESCRIPTION
Fra Norg mottar vi fremdeles tilhørighet til HMS Akershus. Disse skal håndteres av HMS Oslo. Bærum blir allerede arbeidsfordelt til HMS Vest-Viken.

Varsler til Slack dersom vi mottar annen uventet HMS enhet.