### PR TITLE
Annuler anmodningsbehov ved ordreannulering

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -8,7 +8,7 @@ on:
       - "CODEOWNERS"
     branches:
       - main
-      - fix-marker-alle-delerUtenDekning-som-behandlet
+      #- annuler-anmodningsbehov-ved-ordreannulering
 
 jobs:
   build:

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/DelUtenDekningDao.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/DelUtenDekningDao.kt
@@ -78,12 +78,12 @@ class DelUtenDekningDao(val tx: JdbcOperations) {
         )
     }
 
-    fun annulerSak(saksnummer: Long) {
-        log.info { "Annulerer eventuelle deler_uten_dekning-rader som ikke er behandlet for sak $saksnummer" }
+    fun annullerDelerUtenDekning(saksnummer: Long) {
+        log.info { "Annullerer eventuelle deler_uten_dekning-rader som ikke er behandlet for sak $saksnummer" }
         tx.update(
             """
                 UPDATE deler_uten_dekning
-                SET status = 'ANNULERT'
+                SET status = 'ANNULLERT'
                 WHERE saksnummer = :saksnummer
                 AND status='AVVENTER'
             """.trimIndent(),

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/DelUtenDekningDao.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/DelUtenDekningDao.kt
@@ -42,8 +42,7 @@ class DelUtenDekningDao(val tx: JdbcOperations) {
         sql = """
             SELECT DISTINCT(enhetnr)
             FROM deler_uten_dekning
-            WHERE behandlet_tidspunkt IS NULL 
-                AND status='AVVENTER'
+            WHERE status='AVVENTER'
         """.trimIndent()
     ) { row -> Lager.fraLagernummer(row.string("enhetnr")) }
 
@@ -54,7 +53,6 @@ class DelUtenDekningDao(val tx: JdbcOperations) {
                 SELECT hmsnr, navn, SUM(antall_uten_dekning) as antall
                 FROM deler_uten_dekning
                 WHERE enhetnr = :enhetnr 
-                    AND behandlet_tidspunkt IS NULL
                     AND status='AVVENTER'
                 GROUP BY hmsnr, navn
             """.trimIndent(),
@@ -71,7 +69,6 @@ class DelUtenDekningDao(val tx: JdbcOperations) {
                 SET behandlet_tidspunkt = CURRENT_TIMESTAMP,
                     status = 'BEHANDLET'
                 WHERE enhetnr = :enhetnr 
-                    AND behandlet_tidspunkt IS NULL
                     AND status='AVVENTER'
                     AND hmsnr IN (${indexedHmsnrs.joinToString(",") { (index, _) -> ":hmsnr_$index" }})
             """.trimIndent(),

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/DelUtenDekningDao.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/DelUtenDekningDao.kt
@@ -5,7 +5,6 @@ import no.nav.hjelpemidler.database.JdbcOperations
 import no.nav.hjelpemidler.database.Row
 import no.nav.hjelpemidler.delbestilling.common.Lager
 import no.nav.hjelpemidler.delbestilling.common.Hmsnr
-import no.nav.hjelpemidler.delbestilling.config.isDev
 
 private val log = KotlinLogging.logger {}
 
@@ -34,7 +33,7 @@ class DelUtenDekningDao(val tx: JdbcOperations) {
                 "brukers_kommunenr" to bukersKommunenummer,
                 "brukers_kommunenavn" to brukersKommunenavn,
                 "enhetnr" to enhetnr,
-                "status" to DelerTilAnmodningStatus.AVVENTER.name
+                "status" to DelUtenDekningStatus.AVVENTER.name
             ),
         )
     }
@@ -72,7 +71,8 @@ class DelUtenDekningDao(val tx: JdbcOperations) {
                 SET behandlet_tidspunkt = CURRENT_TIMESTAMP,
                     status = 'BEHANDLET'
                 WHERE enhetnr = :enhetnr 
-                    AND behandlet_tidspunkt IS NULL 
+                    AND behandlet_tidspunkt IS NULL
+                    AND status='AVVENTER'
                     AND hmsnr IN (${indexedHmsnrs.joinToString(",") { (index, _) -> ":hmsnr_$index" }})
             """.trimIndent(),
             mapOf(
@@ -87,7 +87,8 @@ class DelUtenDekningDao(val tx: JdbcOperations) {
             """
                 UPDATE deler_uten_dekning
                 SET status = 'ANNULERT'
-                WHERE saksnummer = :saksnummer  
+                WHERE saksnummer = :saksnummer
+                AND status='AVVENTER'
             """.trimIndent(),
             mapOf(
                 "saksnummer" to saksnummer,

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/Model.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/Model.kt
@@ -22,9 +22,9 @@ enum class DelUtenDekningStatus {
     BEHANDLET,
 
     /**
-     * Den tilhørende ordren/saken ble annulert før raden ble behandlet. Raden er dermed ikke lenger relevant for vurdering av anmodningsbehov.
+     * Den tilhørende ordren/saken ble annullert før raden ble behandlet. Raden er dermed ikke lenger relevant for vurdering av anmodningsbehov.
      */
-    ANNULERT,
+    ANNULLERT,
 }
 
 data class Anmodningrapport(

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/Model.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/Model.kt
@@ -9,6 +9,24 @@ data class Del(
     val antall: Int,
 )
 
+enum class DelerTilAnmodningStatus {
+    /**
+     * Venter på behandling ved nattlig jobb.
+     */
+    AVVENTER,
+
+    /**
+     * Raden er behandlet. Delbehovet har enten blitt dekket av etterfylling i løpet av dagen,
+     * eller så har det blitt sendt ut mail om anmodningsbehov.
+     */
+    BEHANDLET,
+
+    /**
+     * Den tilhørene ordren/saken ble annulert før raden ble behandlet. Raden er dermed ikke lenger relevant for vurdering av anmodningsbehov.
+     */
+    ANNULERT,
+}
+
 data class Anmodningrapport(
     val lager: Lager,
     val anmodningsbehov: List<AnmodningsbehovForDel>,

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/Model.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/Model.kt
@@ -9,7 +9,7 @@ data class Del(
     val antall: Int,
 )
 
-enum class DelerTilAnmodningStatus {
+enum class DelUtenDekningStatus {
     /**
      * Venter på behandling ved nattlig jobb.
      */

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/Model.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/anmodning/Model.kt
@@ -22,7 +22,7 @@ enum class DelUtenDekningStatus {
     BEHANDLET,
 
     /**
-     * Den tilhørene ordren/saken ble annulert før raden ble behandlet. Raden er dermed ikke lenger relevant for vurdering av anmodningsbehov.
+     * Den tilhørende ordren/saken ble annulert før raden ble behandlet. Raden er dermed ikke lenger relevant for vurdering av anmodningsbehov.
      */
     ANNULERT,
 }

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/geografi/Kommuneoppslag.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/geografi/Kommuneoppslag.kt
@@ -5,7 +5,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 private val log = KotlinLogging.logger { }
 
 class Kommuneoppslag(
-    private val oppslagClient: OppslagClient
+    private val oppslagClient: OppslagClientInterface
 ) {
 
     suspend fun kommunenavnOrNull(kommunenr: String): String? {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/geografi/OppslagClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/geografi/OppslagClient.kt
@@ -14,9 +14,9 @@ import no.nav.hjelpemidler.delbestilling.infrastructure.navCorrelationId
 class OppslagClient(
     private val client: HttpClient = defaultHttpClient(),
     private val url: String = AppConfig.OPPSLAG_API_URL,
-) {
+): OppslagClientInterface {
 
-    suspend fun hentKommune(kommunenr: String): KommuneDto {
+    override suspend fun hentKommune(kommunenr: String): KommuneDto {
         return withContext(Dispatchers.IO) {
             client.get("$url/api/geografi/kommuner/$kommunenr") {
                 headers {

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/geografi/OppslagClientInterface.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/infrastructure/geografi/OppslagClientInterface.kt
@@ -1,0 +1,7 @@
+package no.nav.hjelpemidler.delbestilling.infrastructure.geografi
+
+
+interface OppslagClientInterface {
+    suspend fun hentKommune(kommunenr: String): KommuneDto
+}
+

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/ordrestatus/DelbestillingStatusService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/ordrestatus/DelbestillingStatusService.kt
@@ -32,6 +32,10 @@ class DelbestillingStatusService(
 
             delbestillingRepository.oppdaterDelbestillingSak(oppdatertDelbestilling)
 
+            if (status == Status.ANNULLERT) {
+                delUtenDekningDao.annulerSak(saksnummer)
+            }
+
             return@transaction oppdatertDelbestilling
         }
 

--- a/src/main/kotlin/no/nav/hjelpemidler/delbestilling/ordrestatus/DelbestillingStatusService.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/delbestilling/ordrestatus/DelbestillingStatusService.kt
@@ -33,7 +33,7 @@ class DelbestillingStatusService(
             delbestillingRepository.oppdaterDelbestillingSak(oppdatertDelbestilling)
 
             if (status == Status.ANNULLERT) {
-                delUtenDekningDao.annulerSak(saksnummer)
+                delUtenDekningDao.annullerDelerUtenDekning(saksnummer)
             }
 
             return@transaction oppdatertDelbestilling

--- a/src/main/resources/db/migration/V14__add_deler_uten_dekning_status.sql
+++ b/src/main/resources/db/migration/V14__add_deler_uten_dekning_status.sql
@@ -1,2 +1,3 @@
+-- Denne migreringen har desverre et misvisende navn som ikke ble oppdaget før etter at migreringen var prodsatt.
 ALTER TABLE deler_uten_dekning
     RENAME COLUMN rapportert_tidspunkt TO behandlet_tidspunkt;

--- a/src/main/resources/db/migration/V16__add_deler_uten_dekning_status.sql
+++ b/src/main/resources/db/migration/V16__add_deler_uten_dekning_status.sql
@@ -1,0 +1,9 @@
+ALTER TABLE deler_uten_dekning
+    ADD COLUMN status VARCHAR(30) NOT NULL DEFAULT 'AVVENTER';
+
+UPDATE deler_uten_dekning
+SET status = 'BEHANDLET'
+WHERE behandlet_tidspunkt IS NOT NULL;
+
+ALTER TABLE deler_uten_dekning
+    ALTER COLUMN status DROP DEFAULT;

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingServiceTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/delbestilling/DelbestillingServiceTest.kt
@@ -1,17 +1,10 @@
 package no.nav.hjelpemidler.delbestilling.delbestilling
 
-import io.mockk.coEvery
-import io.mockk.mockk
-import kotlinx.coroutines.test.runTest
-import no.nav.hjelpemidler.delbestilling.common.Lager
-import no.nav.hjelpemidler.delbestilling.testdata.delLinje
-import no.nav.hjelpemidler.delbestilling.testdata.delbestillerRolle
-import no.nav.hjelpemidler.delbestilling.delbestilling.anmodning.AnmodningService
-import no.nav.hjelpemidler.delbestilling.delbestilling.anmodning.lagerstatus
-import no.nav.hjelpemidler.delbestilling.testdata.delbestillingRequest
 import no.nav.hjelpemidler.delbestilling.infrastructure.oebs.OebsPersoninfo
 import no.nav.hjelpemidler.delbestilling.testdata.PdlRespons
 import no.nav.hjelpemidler.delbestilling.testdata.Testdata
+import no.nav.hjelpemidler.delbestilling.testdata.delLinje
+import no.nav.hjelpemidler.delbestilling.testdata.delbestillingRequest
 import no.nav.hjelpemidler.delbestilling.testdata.fixtures.hentDelUtenDekning
 import no.nav.hjelpemidler.delbestilling.testdata.fixtures.hentDelbestillinger
 import no.nav.hjelpemidler.delbestilling.testdata.fixtures.hentDelerUtenDekning
@@ -24,50 +17,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 internal class DelbestillingServiceTest {
-
-    /*val brukersFnr = "26928698180"
-    val bestillerFnr = "13820599335"
-    val teknikerNavn = "Turid Tekniker"
-    val brukersKommunenr = "1234"
-
-    private var ds = TestDatabase.testDataSource
-    private val transaction = Transaction(ds, TransactionScopeFactory())
-    private val pdl = mockk<Pdl>().apply {
-        coEvery { hentKommunenummer(any()) } returns brukersKommunenr
-        coEvery { hentFornavn(any()) } returns teknikerNavn
-    }
-    private val kommuneoppslag = mockk<Kommuneoppslag>(relaxed = true).apply {
-        coEvery { kommunenavnOrNull(any()) } returns "Oslo"
-    }
-    private val lagerstatusMock = listOf(
-        lagerstatus(hmsnr = "150817", antall = 10),
-        lagerstatus(hmsnr = "278247", antall = 10),
-    )
-    private val oebs = mockk<Oebs>(relaxed = true).apply {
-        coEvery { hentPersoninfo(any()) } returns listOf(OebsPersoninfo(brukersKommunenr))
-        coEvery { hentFnrLeietaker(any(), any()) } returns brukersFnr
-        coEvery { hentLagerstatusForKommunenummer(any(), any()) } returns lagerstatusMock
-    }
-
-    private val slack = mockk<Slack>(relaxed = true)
-    private val anmodningService = mockk<AnmodningService>(relaxed = true)
-    private val delbestillingService =
-        DelbestillingService(
-            transaction,
-            pdl,
-            oebs,
-            kommuneoppslag,
-            mockk(relaxed = true),
-            slack,
-            anmodningService,
-        )
-
-    @BeforeEach
-    fun setup() {
-        TestDatabase.cleanAndMigratedDataSource(ds)
-    }
-
-     */
 
     @Test
     fun `opprettDelbestilling happy path`() = runWithTestContext {
@@ -209,10 +158,10 @@ internal class DelbestillingServiceTest {
             )
         )
 
-        with (hentDelerUtenDekning()) {
+        with(hentDelerUtenDekning()) {
             assertEquals(2, size)
-            assertEquals(-(2-3-2), find { it.hmsnr == hmsnr1 }!!.antall)
-            assertEquals(-(2-2-2), find { it.hmsnr == hmsnr2 }!!.antall)
+            assertEquals(-(2 - 3 - 2), find { it.hmsnr == hmsnr1 }!!.antall)
+            assertEquals(-(2 - 2 - 2), find { it.hmsnr == hmsnr2 }!!.antall)
         }
     }
 }

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/fakes/GraphClientFake.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/fakes/GraphClientFake.kt
@@ -1,0 +1,19 @@
+package no.nav.hjelpemidler.delbestilling.fakes
+
+import no.nav.hjelpemidler.delbestilling.infrastructure.email.GraphClientInterface
+
+class GraphClientFake : GraphClientInterface {
+
+    val outbox = mutableListOf<SendtEmail>()
+
+    override suspend fun sendEmail(recipentEmail: String, subject: String, bodyText: String) {
+        outbox.add(SendtEmail(recipentEmail, subject, bodyText))
+    }
+
+}
+
+data class SendtEmail(
+    val recipent: String,
+    val subject: String,
+    val body: String,
+)

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/fakes/OebsSinkFake.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/fakes/OebsSinkFake.kt
@@ -10,9 +10,14 @@ class OebsSinkFake(
 
     private val ordrer = mutableListOf<Ordre>()
 
-    fun sisteOrdre() = ordrer.last()
+    var skalKasteFeil: Boolean = false
+    var feil: Throwable = RuntimeException("Fake feil")
 
     override fun sendDelbestilling(ordre: Ordre) {
+        if (skalKasteFeil) {
+            throw feil
+        }
+
         ordrer.add(ordre)
         ordre.artikler.forEach {
             lager.reduser(it.hmsnr, it.antall)

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/fakes/OppslagClientFake.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/fakes/OppslagClientFake.kt
@@ -1,0 +1,20 @@
+package no.nav.hjelpemidler.delbestilling.fakes
+
+import no.nav.hjelpemidler.delbestilling.infrastructure.geografi.KommuneDto
+import no.nav.hjelpemidler.delbestilling.infrastructure.geografi.OppslagClientInterface
+
+class OppslagClientFake : OppslagClientInterface {
+
+    val data = mapOf(
+        "0301" to KommuneDto(
+            fylkesnummer = "03",
+            fylkesnavn = "Oslo",
+            kommunenummer = "0301",
+            kommunenavn = "Oslo",
+        ),
+    )
+
+    override suspend fun hentKommune(kommunenr: String): KommuneDto {
+        return data[kommunenr] ?: error("Mangler kommune '$kommunenr'")
+    }
+}

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/ordrestatus/DelbestillingStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/ordrestatus/DelbestillingStatusServiceTest.kt
@@ -4,7 +4,7 @@ import no.nav.hjelpemidler.delbestilling.common.DellinjeStatus
 import no.nav.hjelpemidler.delbestilling.common.Status
 import no.nav.hjelpemidler.delbestilling.delbestilling.anmodning.DelUtenDekningStatus
 import no.nav.hjelpemidler.delbestilling.testdata.Testdata
-import no.nav.hjelpemidler.delbestilling.testdata.fixtures.annulerSak
+import no.nav.hjelpemidler.delbestilling.testdata.fixtures.annullerSak
 import no.nav.hjelpemidler.delbestilling.testdata.fixtures.hentDelUtenDekning
 import no.nav.hjelpemidler.delbestilling.testdata.fixtures.hentDelbestilling
 import no.nav.hjelpemidler.delbestilling.testdata.fixtures.hentRader
@@ -22,7 +22,6 @@ import java.time.LocalDate
 import java.util.TimeZone
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 
 class DelbestillingStatusServiceTest {
@@ -120,28 +119,28 @@ class DelbestillingStatusServiceTest {
     }
 
     @Test
-    fun `skal annulere deler_uten_dekning for relevant sak`() = runWithTestContext {
+    fun `skal annullere deler_uten_dekning for relevant sak`() = runWithTestContext {
         lager.tømAlleDeler()
         val hmsnr = Testdata.defaultDelHmsnr
 
         opprettDelbestillingMedDel(hmsnr, antall = 2)
-        val saksnummerTilAnnulering = opprettDelbestillingMedDel(hmsnr, antall = 3).saksnummer!!
+        val saksnummerTilAnnullering = opprettDelbestillingMedDel(hmsnr, antall = 3).saksnummer!!
 
         assertEquals(5, hentDelUtenDekning(hmsnr).antall, "Alle deler (2+3) skal ligge til anmodning")
 
-        annulerSak(saksnummerTilAnnulering)
+        annullerSak(saksnummerTilAnnullering)
 
-        assertEquals(2, hentDelUtenDekning(hmsnr).antall, "Kun delen som ikke er annulert skal ligge til anmodning")
+        assertEquals(2, hentDelUtenDekning(hmsnr).antall, "Kun delen som ikke er annullert skal ligge til anmodning")
     }
 
     @Test
-    fun `skal ikke annulere sak som er ferdig anmodet`() = runWithTestContext {
+    fun `skal ikke annullere sak som er ferdig anmodet`() = runWithTestContext {
         lager.tømAlleDeler()
         val hmsnr = Testdata.defaultDelHmsnr
 
         val saksnummer = opprettDelbestillingMedDel(hmsnr, antall = 3).saksnummer!!
         delbestillingService.rapporterDelerTilAnmodning()
-        annulerSak(saksnummer)
+        annullerSak(saksnummer)
 
         val rader = transaction { delUtenDekningDao.hentRader() }
         assertEquals(1, rader.size)

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/ordrestatus/DelbestillingStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/ordrestatus/DelbestillingStatusServiceTest.kt
@@ -1,178 +1,133 @@
 package no.nav.hjelpemidler.delbestilling.ordrestatus
 
-import io.mockk.coEvery
-import io.mockk.mockk
-import kotlinx.coroutines.test.runTest
 import no.nav.hjelpemidler.delbestilling.common.DellinjeStatus
 import no.nav.hjelpemidler.delbestilling.common.Status
-import no.nav.hjelpemidler.delbestilling.delbestilling.DelbestillingService
-import no.nav.hjelpemidler.delbestilling.delbestilling.anmodning.AnmodningService
-import no.nav.hjelpemidler.delbestilling.delbestilling.anmodning.lagerstatus
-import no.nav.hjelpemidler.delbestilling.infrastructure.geografi.Kommuneoppslag
-import no.nav.hjelpemidler.delbestilling.infrastructure.oebs.Oebs
-import no.nav.hjelpemidler.delbestilling.infrastructure.oebs.OebsPersoninfo
-import no.nav.hjelpemidler.delbestilling.infrastructure.pdl.Pdl
-import no.nav.hjelpemidler.delbestilling.infrastructure.persistence.transaction.Transaction
-import no.nav.hjelpemidler.delbestilling.infrastructure.persistence.transaction.TransactionScopeFactory
-import no.nav.hjelpemidler.delbestilling.infrastructure.slack.Slack
-import no.nav.hjelpemidler.delbestilling.testdata.TestDatabase
-import no.nav.hjelpemidler.delbestilling.testdata.delbestillerRolle
-import no.nav.hjelpemidler.delbestilling.testdata.delbestillingRequest
+import no.nav.hjelpemidler.delbestilling.testdata.Testdata
+import no.nav.hjelpemidler.delbestilling.testdata.fixtures.annulerSak
+import no.nav.hjelpemidler.delbestilling.testdata.fixtures.hentDelUtenDekning
+import no.nav.hjelpemidler.delbestilling.testdata.fixtures.hentDelbestilling
+import no.nav.hjelpemidler.delbestilling.testdata.fixtures.oppdaterDellinjeStatus
+import no.nav.hjelpemidler.delbestilling.testdata.fixtures.opprettDelbestilling
+import no.nav.hjelpemidler.delbestilling.testdata.fixtures.opprettDelbestillingMedDel
+import no.nav.hjelpemidler.delbestilling.testdata.fixtures.opprettDelbestillingMedDeler
+import no.nav.hjelpemidler.delbestilling.testdata.runWithTestContext
 import no.nav.hjelpemidler.time.TIME_ZONE_EUROPE_OSLO
 import org.junit.jupiter.api.Test
-
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.util.TimeZone
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 
-// TODO rydd opp i testene her. Bruk fakes og opprett egne IT for repository.
 class DelbestillingStatusServiceTest {
 
-    val brukersFnr = "26928698180"
-    val bestillerFnr = "13820599335"
-    val teknikerNavn = "Turid Tekniker"
-    val brukersKommunenr = "1234"
-    val oebsOrdrenummer = "8725414"
-
-    private var ds = TestDatabase.testDataSource
-    private val transaction = Transaction(ds, TransactionScopeFactory())
-    private val pdl = mockk<Pdl>().apply {
-        coEvery { hentKommunenummer(any()) } returns brukersKommunenr
-        coEvery { hentFornavn(any()) } returns teknikerNavn
-    }
-    private val kommuneoppslag = mockk<Kommuneoppslag>(relaxed = true).apply {
-        coEvery { kommunenavnOrNull(any()) } returns "Oslo"
-    }
-    private val lagerstatusMock = listOf(
-        lagerstatus(hmsnr = "150817", antall = 10),
-        lagerstatus(hmsnr = "278247", antall = 10),
-    )
-    private val oebs = mockk<Oebs>(relaxed = true).apply {
-        coEvery { hentPersoninfo(any()) } returns listOf(OebsPersoninfo(brukersKommunenr))
-        coEvery { hentFnrLeietaker(any(), any()) } returns brukersFnr
-        coEvery { hentLagerstatusForKommunenummer(any(), any()) } returns lagerstatusMock
-    }
-
-    private val slack = mockk<Slack>(relaxed = true)
-    private val anmodningService = mockk<AnmodningService>(relaxed = true)
-    private val delbestillingService =
-        DelbestillingService(
-            transaction,
-            pdl,
-            oebs,
-            kommuneoppslag,
-            mockk(relaxed = true),
-            slack,
-            anmodningService,
-        )
-
-    private val delbestillingStatusService = DelbestillingStatusService(transaction, oebs, mockk(relaxed = true), slack)
-
-    @BeforeEach
-    fun setup() {
-        TestDatabase.cleanAndMigratedDataSource(ds)
-    }
-
     @Test
-    fun `skal ikke kunne oppdatere delbestilling til en tidligere status`() = runTest {
-        delbestillingService.opprettDelbestilling(delbestillingRequest(), bestillerFnr, delbestillerRolle())
-        val delbestilling = delbestillingService.hentDelbestillinger(bestillerFnr).first()
-        delbestillingStatusService.oppdaterStatus(delbestilling.saksnummer, Status.KLARGJORT, oebsOrdrenummer)
+    fun `delbestilling skal få status INNSENDT ved innsending`() = runWithTestContext {
+        val saksnummer = opprettDelbestilling().saksnummer!!
 
-        // Denne skal ikke ha noen effekt
-        delbestillingStatusService.oppdaterStatus(delbestilling.saksnummer, Status.REGISTRERT, oebsOrdrenummer)
-
-        assertEquals(Status.KLARGJORT, delbestillingService.hentDelbestillinger(bestillerFnr).first().status)
-    }
-
-    @Test
-    fun `skal oppdatere delbestilling status`() = runTest {
-        delbestillingService.opprettDelbestilling(delbestillingRequest(), bestillerFnr, delbestillerRolle())
-        val delbestilling = delbestillingService.hentDelbestillinger(bestillerFnr).first()
-        assertEquals(Status.INNSENDT, delbestilling.status)
-        assertEquals(null, delbestilling.oebsOrdrenummer)
-
-        delbestillingStatusService.oppdaterStatus(delbestilling.saksnummer, Status.KLARGJORT, oebsOrdrenummer)
-        val oppdatertDelbestilling = delbestillingService.hentDelbestillinger(bestillerFnr).first()
-        assertEquals(Status.KLARGJORT, oppdatertDelbestilling.status)
-        assertEquals(oebsOrdrenummer, oppdatertDelbestilling.oebsOrdrenummer)
-    }
-
-    @Test
-    fun `statusoppdatering skal feile når det er mismatch i oebsOrdrenummer`() = runTest {
-        delbestillingService.opprettDelbestilling(delbestillingRequest(), bestillerFnr, delbestillerRolle())
-        val delbestilling = delbestillingService.hentDelbestillinger(bestillerFnr).first()
-        delbestillingStatusService.oppdaterStatus(delbestilling.saksnummer, Status.REGISTRERT, oebsOrdrenummer)
-        assertThrows<IllegalArgumentException> {
-            delbestillingStatusService.oppdaterStatus(delbestilling.saksnummer, Status.REGISTRERT, "123")
+        with(hentDelbestilling(saksnummer)) {
+            assertEquals(Status.INNSENDT, status)
+            assertEquals(null, oebsOrdrenummer)
         }
     }
 
     @Test
-    fun `skal oppdatere status på dellinjer`() = runTest {
+    fun `skal oppdatere status på delbestilling`() = runWithTestContext {
+        val saksnummer = opprettDelbestilling().saksnummer!!
+        val oebsOrdrenummer = "123"
+        delbestillingStatusService.oppdaterStatus(saksnummer, Status.KLARGJORT, oebsOrdrenummer)
+
+        with(hentDelbestilling(saksnummer)) {
+            assertEquals(Status.KLARGJORT, this.status)
+            assertEquals(oebsOrdrenummer, this.oebsOrdrenummer)
+        }
+    }
+
+    @Test
+    fun `skal ikke kunne oppdatere delbestilling til en tidligere status`() = runWithTestContext {
+        val saksnummer = opprettDelbestilling().saksnummer!!
+        val oebsOrdrenummer = "123"
+
+        delbestillingStatusService.oppdaterStatus(saksnummer, Status.KLARGJORT, oebsOrdrenummer)
+
+        // Denne skal ikke ha noen effekt
+        delbestillingStatusService.oppdaterStatus(saksnummer, Status.REGISTRERT, oebsOrdrenummer)
+
+        with(hentDelbestilling(saksnummer)) {
+            assertEquals(Status.KLARGJORT, status)
+        }
+    }
+
+    @Test
+    fun `statusoppdatering skal feile når det er mismatch i oebsOrdrenummer`() = runWithTestContext {
+        val saksnummer = opprettDelbestilling().saksnummer!!
+        delbestillingStatusService.oppdaterStatus(saksnummer, Status.REGISTRERT, "111")
+
+        assertThrows<IllegalArgumentException> {
+            delbestillingStatusService.oppdaterStatus(saksnummer, Status.REGISTRERT, "222")
+        }
+    }
+
+    @Test
+    fun `skal oppdatere status på dellinjer`() = runWithTestContext {
         // Appen vil alltid kjøre med Europe/Oslo (ref. Dockerimage), men setter det eksplisitt her pga Github Runners bruker UTC
         TimeZone.setDefault(TIME_ZONE_EUROPE_OSLO)
 
-        delbestillingService.opprettDelbestilling(delbestillingRequest(), bestillerFnr, delbestillerRolle())
-        var delbestilling = delbestillingService.hentDelbestillinger(bestillerFnr).first()
-        delbestillingStatusService.oppdaterStatus(delbestilling.saksnummer, Status.KLARGJORT, oebsOrdrenummer)
-        val datoOppdatert = LocalDate.of(2023, 9, 29)
+        val oebsOrdrenummer = "8725414"
+        val hmsnrDel1 = "111111"
+        val hmsnrDel2 = "222222"
+
+        val saksnummer = opprettDelbestillingMedDeler(hmsnrDel1, hmsnrDel2).saksnummer!!
+
+        delbestillingStatusService.oppdaterStatus(saksnummer, Status.KLARGJORT, oebsOrdrenummer)
 
         // Skipningsbekreft første del
+        val datoSkipningsbekreftet = LocalDate.of(2023, 9, 29)
         delbestillingStatusService.oppdaterDellinjeStatus(
             oebsOrdrenummer,
             DellinjeStatus.SKIPNINGSBEKREFTET,
-            delbestilling.delbestilling.deler[0].del.hmsnr,
-            datoOppdatert
+            hmsnrDel1,
+            datoSkipningsbekreftet
         )
-        delbestilling = delbestillingService.hentDelbestillinger(bestillerFnr).first()
-        assertEquals(Status.DELVIS_SKIPNINGSBEKREFTET, delbestilling.status)
-        assertEquals(DellinjeStatus.SKIPNINGSBEKREFTET, delbestilling.delbestilling.deler[0].status)
-        assertEquals(datoOppdatert, delbestilling.delbestilling.deler[0].datoSkipningsbekreftet)
-        assertEquals(LocalDate.of(2023, 10, 2), delbestilling.delbestilling.deler[0].forventetLeveringsdato)
 
-        assertEquals(null, delbestilling.delbestilling.deler[1].status)
-        assertEquals(null, delbestilling.delbestilling.deler[1].datoSkipningsbekreftet)
-        assertEquals(null, delbestilling.delbestilling.deler[1].forventetLeveringsdato)
+        with(hentDelbestilling(saksnummer)) {
+            assertEquals(Status.DELVIS_SKIPNINGSBEKREFTET, status)
 
-        // Skipningsbekreft andre del
-        delbestillingStatusService.oppdaterDellinjeStatus(
-            oebsOrdrenummer,
-            DellinjeStatus.SKIPNINGSBEKREFTET,
-            delbestilling.delbestilling.deler[1].del.hmsnr,
-            datoOppdatert
-        )
-        delbestilling = delbestillingService.hentDelbestillinger(bestillerFnr).first()
-        assertEquals(Status.SKIPNINGSBEKREFTET, delbestilling.status)
-        assertEquals(DellinjeStatus.SKIPNINGSBEKREFTET, delbestilling.delbestilling.deler[0].status)
-        assertEquals(DellinjeStatus.SKIPNINGSBEKREFTET, delbestilling.delbestilling.deler[1].status)
+            val del1 = delbestilling.deler.first { it.del.hmsnr == hmsnrDel1 }
+            assertEquals(DellinjeStatus.SKIPNINGSBEKREFTET, del1.status)
+            assertEquals(datoSkipningsbekreftet, del1.datoSkipningsbekreftet)
+            assertEquals(LocalDate.of(2023, 10, 2), del1.forventetLeveringsdato)
+
+            val del2 = delbestilling.deler.first { it.del.hmsnr == hmsnrDel2 }
+            assertNull(del2.status)
+            assertNull(del2.datoSkipningsbekreftet)
+            assertNull(del2.forventetLeveringsdato)
+        }
     }
 
     @Test
-    fun `skal ignorere skipningsbekreftelse for ukjent ordrenr`() = runTest {
-        var delbestilling = transaction {
-            delbestillingRepository.hentDelbestilling(oebsOrdrenummer)
-        }
-        assertNull(delbestilling)
+    fun `skal ignorere skipningsbekreftelse for ukjent ordrenr`() = runWithTestContext {
+        val oebsOrdrenummer = "8725414"
+        assertNull(hentDelbestilling(oebsOrdrenummer))
 
-        // Skal bare ignorere ukjent ordrenummer
-        assertDoesNotThrow {
-            delbestillingStatusService.oppdaterDellinjeStatus(
-                oebsOrdrenummer,
-                DellinjeStatus.SKIPNINGSBEKREFTET,
-                "123456",
-                LocalDate.now(),
-            )
-        }
+        assertDoesNotThrow { oppdaterDellinjeStatus(oebsOrdrenummer) }
+    }
 
-        delbestilling = transaction {
-            delbestillingRepository.hentDelbestilling(oebsOrdrenummer)
-        }
-        assertNull(delbestilling)
+    @Test
+    fun `skal annulere deler_uten_dekning for relevant sak`() = runWithTestContext {
+        lager.tømAlleDeler()
+
+        val hmsnr = Testdata.defaultDelHmsnr
+
+        opprettDelbestillingMedDel(hmsnr, antall = 2)
+        val saksnummerTilAnnulering = opprettDelbestillingMedDel(hmsnr, antall = 3).saksnummer!!
+
+        assertEquals(5, hentDelUtenDekning(hmsnr).antall, "Alle deler (2+3) skal ligge til anmodning")
+
+        annulerSak(saksnummerTilAnnulering)
+
+        assertEquals(2, hentDelUtenDekning(hmsnr).antall, "Kun delen som ikke er annulert skal ligge til anmodning")
     }
 }

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/FakeOebsLager.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/FakeOebsLager.kt
@@ -1,6 +1,7 @@
 package no.nav.hjelpemidler.delbestilling.testdata
 
 import no.nav.hjelpemidler.delbestilling.common.Hmsnr
+import no.nav.hjelpemidler.delbestilling.common.Lager
 import no.nav.hjelpemidler.delbestilling.infrastructure.oebs.LagerstatusResponse
 
 class FakeOebsLager {
@@ -9,6 +10,10 @@ class FakeOebsLager {
     init {
         set(Testdata.delPåMinmax, antall = 5, minmax = true)
         set(Testdata.delPåLagerIkkeMinmax, antall = 5, minmax = false)
+    }
+
+    fun tømAlleDeler() {
+        store.clear()
     }
 
     fun set(hmsnr: Hmsnr, antall: Int, minmax: Boolean = true, orgId: Int = 243, orgNavn: String = "*03 Oslo") {

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/Testdata.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/Testdata.kt
@@ -1,5 +1,7 @@
 package no.nav.hjelpemidler.delbestilling.testdata
 
+import no.nav.hjelpemidler.delbestilling.common.Lager
+
 
 object Testdata {
 
@@ -14,6 +16,9 @@ object Testdata {
     val delPåLagerIkkeMinmax = "168803"
 
     val kommunenummerOslo = "0301"
+    val kommunenummerBergen = "4601"
     val defaultKommunenummer = kommunenummerOslo
     val defaultKommunenavn = "Oslo"
+
+    val defaultEnhet = Lager.OSLO
 }

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/Testhjelpere.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/Testhjelpere.kt
@@ -17,7 +17,13 @@ import java.util.UUID
 
 fun delbestillerRolle(
     kanBestilleDeler: Boolean = true,
-    kommunaleAnsettelsesforhold: List<Organisasjon> = listOf(Organisasjon("123", "navn", kommunenummer = "1234"))
+    kommunaleAnsettelsesforhold: List<Organisasjon> = listOf(
+        Organisasjon(
+            "123",
+            Testdata.defaultKommunenavn,
+            kommunenummer = Testdata.defaultKommunenummer
+        )
+    )
 ) = Delbestiller(
     kanBestilleDeler = kanBestilleDeler,
     kommunaleAnsettelsesforhold = kommunaleAnsettelsesforhold,

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelUtenDekningFixtures.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelUtenDekningFixtures.kt
@@ -1,11 +1,14 @@
 package no.nav.hjelpemidler.delbestilling.testdata.fixtures
 
+import no.nav.hjelpemidler.database.Row
 import no.nav.hjelpemidler.delbestilling.common.Hmsnr
 import no.nav.hjelpemidler.delbestilling.common.Lager
 import no.nav.hjelpemidler.delbestilling.delbestilling.anmodning.Del
+import no.nav.hjelpemidler.delbestilling.delbestilling.anmodning.DelUtenDekningDao
+import no.nav.hjelpemidler.delbestilling.delbestilling.anmodning.DelUtenDekningStatus
 import no.nav.hjelpemidler.delbestilling.testdata.TestContext
 import no.nav.hjelpemidler.delbestilling.testdata.Testdata
-import no.nav.hjelpemidler.domain.enhet.Enhet
+import java.time.LocalDateTime
 
 suspend fun TestContext.hentDelerUtenDekning(
     enhet: Lager = Testdata.defaultEnhet,
@@ -21,3 +24,30 @@ suspend fun TestContext.hentDelUtenDekning(
 ): Del {
     return hentDelerUtenDekning().find { it.hmsnr == hmsnr }!!
 }
+
+suspend fun DelUtenDekningDao.hentRader(
+    enhetnr: String = Testdata.defaultEnhet.nummer
+): List<DelUtenDekningEntity> {
+    return tx.list(
+        sql = """
+                SELECT *
+                FROM deler_uten_dekning
+                WHERE enhetnr = :enhetnr
+            """.trimIndent(),
+        queryParameters = mapOf("enhetnr" to enhetnr)
+    ) { it.toDelUtenDekningEntity() }
+}
+
+data class DelUtenDekningEntity(
+    val saksnummer: Long,
+    val hmsnr: Hmsnr,
+    val status: DelUtenDekningStatus,
+    val behandletTidspunkt: LocalDateTime,
+)
+
+private fun Row.toDelUtenDekningEntity() = DelUtenDekningEntity(
+    saksnummer = this.long("saksnummer"),
+    hmsnr = this.string("hmsnr"),
+    status = DelUtenDekningStatus.valueOf(this.string("status")),
+    behandletTidspunkt = this.localDateTime("behandlet_tidspunkt"),
+)

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelUtenDekningFixtures.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelUtenDekningFixtures.kt
@@ -1,0 +1,23 @@
+package no.nav.hjelpemidler.delbestilling.testdata.fixtures
+
+import no.nav.hjelpemidler.delbestilling.common.Hmsnr
+import no.nav.hjelpemidler.delbestilling.common.Lager
+import no.nav.hjelpemidler.delbestilling.delbestilling.anmodning.Del
+import no.nav.hjelpemidler.delbestilling.testdata.TestContext
+import no.nav.hjelpemidler.delbestilling.testdata.Testdata
+import no.nav.hjelpemidler.domain.enhet.Enhet
+
+suspend fun TestContext.hentDelerUtenDekning(
+    enhet: Lager = Testdata.defaultEnhet,
+): List<Del> {
+    return transaction {
+        delUtenDekningDao
+            .hentDelerTilRapportering(enhet.nummer)
+    }
+}
+
+suspend fun TestContext.hentDelUtenDekning(
+    hmsnr: Hmsnr = Testdata.defaultDelHmsnr,
+): Del {
+    return hentDelerUtenDekning().find { it.hmsnr == hmsnr }!!
+}

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelbestillingFixtures.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelbestillingFixtures.kt
@@ -1,11 +1,19 @@
 package no.nav.hjelpemidler.delbestilling.testdata.fixtures
 
 import no.nav.hjelpemidler.delbestilling.common.Delbestilling
+import no.nav.hjelpemidler.delbestilling.common.Hmsnr
 import no.nav.hjelpemidler.delbestilling.delbestilling.BestillerType
+import no.nav.hjelpemidler.delbestilling.delbestilling.DelbestillingRequest
+import no.nav.hjelpemidler.delbestilling.delbestilling.DelbestillingResultat
+import no.nav.hjelpemidler.delbestilling.infrastructure.roller.Delbestiller
 import no.nav.hjelpemidler.delbestilling.testdata.TestContext
 import no.nav.hjelpemidler.delbestilling.testdata.Testdata
+import no.nav.hjelpemidler.delbestilling.testdata.delLinje
+import no.nav.hjelpemidler.delbestilling.testdata.delbestillerRolle
 import no.nav.hjelpemidler.delbestilling.testdata.delbestilling
+import no.nav.hjelpemidler.delbestilling.testdata.delbestillingRequest
 import no.nav.hjelpemidler.delbestilling.testdata.organisasjon
+import no.nav.hjelpemidler.domain.person.Fødselsnummer
 import java.time.LocalDateTime
 
 suspend fun TestContext.gittDelbestilling(
@@ -38,4 +46,38 @@ suspend fun TestContext.gittDelbestilling(
             )
         }
     }
+}
+
+suspend fun TestContext.opprettDelbestilling(
+    request: DelbestillingRequest = delbestillingRequest(),
+    fnrBestiller: String = Testdata.defaultFnr,
+    rolle: Delbestiller = delbestillerRolle()
+): DelbestillingResultat {
+    return delbestillingService.opprettDelbestilling(request, fnrBestiller, rolle)
+}
+
+suspend fun TestContext.opprettDelbestillingMedDel(
+    hmsnr: Hmsnr,
+    antall: Int = 2,
+): DelbestillingResultat {
+    return opprettDelbestilling(
+        request = delbestillingRequest(
+            deler = listOf(
+                delLinje(
+                    hmsnr = hmsnr,
+                    antall = antall
+                )
+            )
+        )
+    )
+}
+
+suspend fun TestContext.opprettDelbestillingMedDeler(
+    vararg hmsnrs: Hmsnr,
+): DelbestillingResultat {
+    return opprettDelbestilling(
+        request = delbestillingRequest(
+            deler = hmsnrs.map { hmsnr -> delLinje(hmsnr = hmsnr) }
+        )
+    )
 }

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelbestillingRepositoryFixtures.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelbestillingRepositoryFixtures.kt
@@ -1,0 +1,27 @@
+package no.nav.hjelpemidler.delbestilling.testdata.fixtures
+
+import no.nav.hjelpemidler.delbestilling.common.DelbestillingSak
+import no.nav.hjelpemidler.delbestilling.testdata.TestContext
+import no.nav.hjelpemidler.delbestilling.testdata.Testdata
+
+suspend fun TestContext.hentDelbestilling(
+    oebsOrdrenummer: String,
+): DelbestillingSak? {
+    return transaction {
+        delbestillingRepository.hentDelbestilling(oebsOrdrenummer)
+    }
+}
+
+suspend fun TestContext.hentDelbestilling(
+    saksnummer: Long,
+): DelbestillingSak {
+    return transaction {
+        delbestillingRepository.hentDelbestilling(saksnummer)
+    }!!
+}
+
+suspend fun TestContext.hentDelbestillinger(
+    fnr: String = Testdata.defaultFnr,
+): List<DelbestillingSak> {
+    return delbestillingService.hentDelbestillinger(fnr)
+}

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelbestillingStatusServiceFixtures.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelbestillingStatusServiceFixtures.kt
@@ -1,0 +1,21 @@
+package no.nav.hjelpemidler.delbestilling.testdata.fixtures
+
+import no.nav.hjelpemidler.delbestilling.common.DellinjeStatus
+import no.nav.hjelpemidler.delbestilling.common.Status
+import no.nav.hjelpemidler.delbestilling.testdata.TestContext
+import java.time.LocalDate
+
+suspend fun TestContext.annulerSak(saksnummer: Long) {
+    delbestillingStatusService.oppdaterStatus(saksnummer, Status.ANNULLERT, "123")
+}
+
+suspend fun TestContext.oppdaterDellinjeStatus(
+    oebsOrdrenummer: String,
+) {
+    delbestillingStatusService.oppdaterDellinjeStatus(
+        oebsOrdrenummer,
+        DellinjeStatus.SKIPNINGSBEKREFTET,
+        "123456",
+        LocalDate.now(),
+    )
+}

--- a/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelbestillingStatusServiceFixtures.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/delbestilling/testdata/fixtures/DelbestillingStatusServiceFixtures.kt
@@ -5,7 +5,7 @@ import no.nav.hjelpemidler.delbestilling.common.Status
 import no.nav.hjelpemidler.delbestilling.testdata.TestContext
 import java.time.LocalDate
 
-suspend fun TestContext.annulerSak(saksnummer: Long) {
+suspend fun TestContext.annullerSak(saksnummer: Long) {
     delbestillingStatusService.oppdaterStatus(saksnummer, Status.ANNULLERT, "123")
 }
 


### PR DESCRIPTION
Legger til ny migrering:
- Legg til `status`-kolonne i `deler_uten_dekning`
- Eksisterende kolonner settes til status=AVVENTER
- Eksisterende kolonner som er behandlet settes til status=BEHANDLET

Legg til sjekk i statusoppdateringen:
- Dersom status er ANNULERT, så settes også rader i deler_uten_dekning til status=ANNULERT for gitt saksnummer.
- Rader som allerede er blitt behandlet ignoreres. Det har allerede blitt sendt ut anmodningsemail for disse, så det er for sent å annulere dem.

DelerUtenDekningDao er justert:
- Sjekker på status=AVVENTER i stedet for behandlet_tidspunkt IS NULL, for henting og behandling av rader.

Tester:
- Lagt til nye tester på annulering (`skal annulere deler_uten_dekning for relevant sak` og `skal ikke annulere sak som er ferdig anmodet`)
- Justert på eksisterende tester til å ta i bruk runWithTestContext. Forsøkt å gjøre dem mer leselige ved å splitte opp og innføring av noen hjelpefunksjoner.